### PR TITLE
removed choice selected indicator after user testing

### DIFF
--- a/choice.go
+++ b/choice.go
@@ -29,7 +29,7 @@ var ChoiceQuestionTemplate = `
 
 var ChoiceChoicesTemplate = `
 {{- range $ix, $choice := .Choices}}
-  {{- if eq $ix $.Selected}}{{color "cyan"}}➤ {{else}}{{color "default+hb"}}  {{end}}
+  {{- if eq $ix $.Selected}}{{color "cyan"}}> {{else}}{{color "default+hb"}}  {{end}}
   {{- $choice}}
   {{- color "reset"}}
 {{end}}`

--- a/choice_test.go
+++ b/choice_test.go
@@ -24,7 +24,7 @@ func TestCanFormatChoiceOptions(t *testing.T) {
 
 	expected := `  foo
   bar
-➤ baz
+> baz
   buz
 `
 


### PR DESCRIPTION
@coryb I showed a few (4) people around me what they thought about the unicode choice selector that you added (which I am still a fan of) and all of them agreed that it looked too bold compared to the rest of the text. I think for now, we should go back to using `>` and maybe we can explore other unicode options later.