### PR TITLE
fix incompat issues between posix and windows EraseInLine arguments

### DIFF
--- a/confirm.go
+++ b/confirm.go
@@ -118,7 +118,7 @@ func (c *Confirm) Cleanup(rl *readline.Instance, val interface{}) error {
 	// go up one line
 	terminal.CursorPreviousLine(1)
 	// clear the line
-	terminal.EraseInLine(terminal.ERASE_LINE_ALL)
+	terminal.EraseLine(terminal.ERASE_LINE_ALL)
 
 	// the string version of the answer
 	ans := ""

--- a/confirm.go
+++ b/confirm.go
@@ -118,7 +118,7 @@ func (c *Confirm) Cleanup(rl *readline.Instance, val interface{}) error {
 	// go up one line
 	terminal.CursorPreviousLine(1)
 	// clear the line
-	terminal.EraseInLine(0)
+	terminal.EraseInLine(terminal.ERASE_LINE_ALL)
 
 	// the string version of the answer
 	ans := ""

--- a/input.go
+++ b/input.go
@@ -52,7 +52,7 @@ func (i *Input) Cleanup(rl *readline.Instance, val interface{}) error {
 	// go up one line
 	terminal.CursorPreviousLine(1)
 	// clear the line
-	terminal.EraseInLine(0)
+	terminal.EraseInLine(terminal.ERASE_LINE_ALL)
 
 	// render the template
 	out, err := core.RunTemplate(

--- a/input.go
+++ b/input.go
@@ -52,7 +52,7 @@ func (i *Input) Cleanup(rl *readline.Instance, val interface{}) error {
 	// go up one line
 	terminal.CursorPreviousLine(1)
 	// clear the line
-	terminal.EraseInLine(terminal.ERASE_LINE_ALL)
+	terminal.EraseLine(terminal.ERASE_LINE_ALL)
 
 	// render the template
 	out, err := core.RunTemplate(

--- a/multiselect.go
+++ b/multiselect.go
@@ -75,7 +75,7 @@ func (m *MultiSelect) render() error {
 	// clean up what we left behind last time
 	for range m.Options {
 		terminal.CursorPreviousLine(1)
-		terminal.EraseInLine(terminal.ERASE_LINE_ALL)
+		terminal.EraseLine(terminal.ERASE_LINE_ALL)
 	}
 
 	// render the template summarizing the current state
@@ -170,10 +170,10 @@ func (m *MultiSelect) Prompt(rl *readline.Instance) (interface{}, error) {
 // Cleanup removes the options section, and renders the ask like a normal question.
 func (m *MultiSelect) Cleanup(rl *readline.Instance, val interface{}) error {
 	terminal.CursorPreviousLine(1)
-	terminal.EraseInLine(terminal.ERASE_LINE_ALL)
+	terminal.EraseLine(terminal.ERASE_LINE_ALL)
 	for range m.Options {
 		terminal.CursorPreviousLine(1)
-		terminal.EraseInLine(terminal.ERASE_LINE_ALL)
+		terminal.EraseLine(terminal.ERASE_LINE_ALL)
 	}
 
 	// execute the output summary template with the answer

--- a/multiselect.go
+++ b/multiselect.go
@@ -75,7 +75,7 @@ func (m *MultiSelect) render() error {
 	// clean up what we left behind last time
 	for range m.Options {
 		terminal.CursorPreviousLine(1)
-		terminal.EraseInLine(0)
+		terminal.EraseInLine(terminal.ERASE_LINE_ALL)
 	}
 
 	// render the template summarizing the current state
@@ -170,10 +170,10 @@ func (m *MultiSelect) Prompt(rl *readline.Instance) (interface{}, error) {
 // Cleanup removes the options section, and renders the ask like a normal question.
 func (m *MultiSelect) Cleanup(rl *readline.Instance, val interface{}) error {
 	terminal.CursorPreviousLine(1)
-	terminal.EraseInLine(0)
+	terminal.EraseInLine(terminal.ERASE_LINE_ALL)
 	for range m.Options {
 		terminal.CursorPreviousLine(1)
-		terminal.EraseInLine(0)
+		terminal.EraseInLine(terminal.ERASE_LINE_ALL)
 	}
 
 	// execute the output summary template with the answer

--- a/select.go
+++ b/select.go
@@ -65,7 +65,7 @@ func (s *Select) OnChange(line []rune, pos int, key rune) (newLine []rune, newPo
 func (s *Select) render() error {
 	for range s.Options {
 		terminal.CursorPreviousLine(1)
-		terminal.EraseInLine(terminal.ERASE_LINE_ALL)
+		terminal.EraseLine(terminal.ERASE_LINE_ALL)
 	}
 
 	// the formatted response
@@ -153,10 +153,10 @@ func (s *Select) Prompt(rl *readline.Instance) (interface{}, error) {
 
 func (s *Select) Cleanup(rl *readline.Instance, val interface{}) error {
 	terminal.CursorPreviousLine(1)
-	terminal.EraseInLine(terminal.ERASE_LINE_ALL)
+	terminal.EraseLine(terminal.ERASE_LINE_ALL)
 	for range s.Options {
 		terminal.CursorPreviousLine(1)
-		terminal.EraseInLine(terminal.ERASE_LINE_ALL)
+		terminal.EraseLine(terminal.ERASE_LINE_ALL)
 	}
 
 	// execute the output summary template with the answer

--- a/select.go
+++ b/select.go
@@ -65,7 +65,7 @@ func (s *Select) OnChange(line []rune, pos int, key rune) (newLine []rune, newPo
 func (s *Select) render() error {
 	for range s.Options {
 		terminal.CursorPreviousLine(1)
-		terminal.EraseInLine(0)
+		terminal.EraseInLine(terminal.ERASE_LINE_ALL)
 	}
 
 	// the formatted response
@@ -153,10 +153,10 @@ func (s *Select) Prompt(rl *readline.Instance) (interface{}, error) {
 
 func (s *Select) Cleanup(rl *readline.Instance, val interface{}) error {
 	terminal.CursorPreviousLine(1)
-	terminal.EraseInLine(0)
+	terminal.EraseInLine(terminal.ERASE_LINE_ALL)
 	for range s.Options {
 		terminal.CursorPreviousLine(1)
-		terminal.EraseInLine(0)
+		terminal.EraseInLine(terminal.ERASE_LINE_ALL)
 	}
 
 	// execute the output summary template with the answer

--- a/terminal/display.go
+++ b/terminal/display.go
@@ -1,11 +1,9 @@
-// +build !windows
-
 package terminal
 
-import (
-	"fmt"
-)
+type EraseLineMode int
 
-func EraseInLine(mode int) {
-	fmt.Printf("\x1b[%dK", mode)
-}
+const (
+	ERASE_LINE_END   EraseLineMode = iota
+	ERASE_LINE_START EraseLineMode = iota
+	ERASE_LINE_ALL   EraseLineMode = iota
+)

--- a/terminal/display.go
+++ b/terminal/display.go
@@ -3,7 +3,7 @@ package terminal
 type EraseLineMode int
 
 const (
-	ERASE_LINE_END   EraseLineMode = iota
-	ERASE_LINE_START EraseLineMode = iota
-	ERASE_LINE_ALL   EraseLineMode = iota
+	ERASE_LINE_END EraseLineMode = iota
+	ERASE_LINE_START
+	ERASE_LINE_ALL
 )

--- a/terminal/display_posix.go
+++ b/terminal/display_posix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package terminal
+
+import (
+	"fmt"
+)
+
+func EraseInLine(mode EraseLineMode) {
+	fmt.Printf("\x1b[%dK", mode)
+}

--- a/terminal/display_posix.go
+++ b/terminal/display_posix.go
@@ -6,6 +6,6 @@ import (
 	"fmt"
 )
 
-func EraseInLine(mode EraseLineMode) {
+func EraseLine(mode EraseLineMode) {
 	fmt.Printf("\x1b[%dK", mode)
 }

--- a/terminal/display_windows.go
+++ b/terminal/display_windows.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-func EraseInLine(mode int) {
+func EraseInLine(mode EraseLineMode) {
 	handle := syscall.Handle(os.Stdout.Fd())
 
 	var csbi consoleScreenBufferInfo
@@ -16,11 +16,11 @@ func EraseInLine(mode int) {
 	var x short
 	cursor := csbi.cursorPosition
 	switch mode {
-	case 1:
+	case ERASE_LINE_END:
 		x = csbi.size.x
-	case 2:
+	case ERASE_LINE_START:
 		x = 0
-	case 3:
+	case ERASE_LINE_ALL:
 		cursor.x = 0
 		x = csbi.size.x
 	}

--- a/terminal/display_windows.go
+++ b/terminal/display_windows.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-func EraseInLine(mode EraseLineMode) {
+func EraseLine(mode EraseLineMode) {
 	handle := syscall.Handle(os.Stdout.Fd())
 
 	var csbi consoleScreenBufferInfo


### PR DESCRIPTION
the posix EraseInLine expected values 0-2, while the windows EraseInLine expected values 1-3.  To resolve the issue I just named several constants to match the posix expected values then in the switch statement for windows use those constants.

From the Wikipedia entry on CSI-n-K usage:
> Erases part of the line. If n is zero (or missing), clear from cursor to the end of the line. If n is one, clear from cursor to beginning of the line. If  n is two, clear entire line. Cursor position does not change.

I have also changed all of the EraseInLine usage to clear the entire line, not just from cursor.  The functionality currently will be the same but if the cursor ever moves during prompting (like some work I am planning on doing) then erasing the entire line is necessary, and the "correct" thing to do in any case I think.