### PR TITLE
Fixed bug with multiple selects in the same readline instance

### DIFF
--- a/select.go
+++ b/select.go
@@ -17,6 +17,7 @@ type Select struct {
 	Options       []string
 	Default       string
 	selectedIndex int
+	useDefault    bool
 }
 
 // the data available to the templates when processing
@@ -47,10 +48,12 @@ func (s *Select) OnChange(line []rune, pos int, key rune) (newLine []rune, newPo
 		return []rune(s.Options[s.selectedIndex]), 0, true
 		// if the user pressed the up arrow
 	} else if key == terminal.KeyArrowUp && s.selectedIndex > 0 {
+		s.useDefault = false
 		// decrement the selected index
 		s.selectedIndex--
 		// if the user pressed down and there is room to move
 	} else if key == terminal.KeyArrowDown && s.selectedIndex < len(s.Options)-1 {
+		s.useDefault = false
 		// increment the selected index
 		s.selectedIndex++
 	}
@@ -130,13 +133,17 @@ func (s *Select) Prompt(rl *readline.Instance) (interface{}, error) {
 	for range s.Options {
 		terminal.Println()
 	}
+	// by default, use the default value
+	s.useDefault = true
+
 	// start waiting for input
-	val, err := rl.Readline()
+	_, err = rl.Readline()
 	// show the cursor when we're done
 	terminal.CursorShow()
 
-	//  if the value is empty (not sure why)
-	if val == "" {
+	var val string
+	// if we are supposed to use the default value
+	if s.useDefault {
 		// if there is a default value
 		if s.Default != "" {
 			// use the default value
@@ -145,9 +152,12 @@ func (s *Select) Prompt(rl *readline.Instance) (interface{}, error) {
 			// there is no default value so use the first
 			val = s.Options[0]
 		}
+		// otherwise the selected index points to the value
+	} else {
+		// the
+		val = s.Options[s.selectedIndex]
 	}
 
-	// return rl.Readline()
 	return val, err
 }
 

--- a/survey.go
+++ b/survey.go
@@ -46,6 +46,7 @@ func Ask(qs []*Question, t interface{}) error {
 	if err != nil {
 		return err
 	}
+	defer rl.Close()
 
 	// if we weren't passed a place to record the answers
 	if t == nil {
@@ -96,6 +97,7 @@ func Ask(qs []*Question, t interface{}) error {
 		if err != nil {
 			return err
 		}
+
 	}
 	// return the response
 	return nil

--- a/tests/doublselect.go
+++ b/tests/doublselect.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/alecaivazis/survey"
+)
+
+var simpleQs = []*survey.Question{
+	{
+		Name: "color",
+		Prompt: &survey.Select{
+			Message: "select1:",
+			Options: []string{"red", "blue", "green"},
+		},
+		Validate: survey.Required,
+	},
+	{
+		Name: "color2",
+		Prompt: &survey.Select{
+			Message: "select2:",
+			Options: []string{"red", "blue", "green"},
+		},
+		Validate: survey.Required,
+	},
+}
+
+func main() {
+	answers := struct {
+		Color  string
+		Color2 string
+	}{}
+	// ask the question
+	err := survey.Ask(simpleQs, &answers)
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	// print the answers
+	fmt.Printf("%s and %s.\n", answers.Color, answers.Color2)
+}


### PR DESCRIPTION
This PR hopefully address a bug reported by @rv-zjohnson in #36 where after the first select had made a decision, the readline instance was returning its value in situations where it should return the default value of the sesequent selects