### PR TITLE
fixed input cleanup when default is empty string

### DIFF
--- a/input.go
+++ b/input.go
@@ -18,8 +18,9 @@ type Input struct {
 // data available to the templates when processing
 type InputTemplateData struct {
 	Input
-	Answer   string
-	ShowHelp bool
+	Answer     string
+	ShowAnswer bool
+	ShowHelp   bool
 }
 
 // Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
@@ -27,7 +28,7 @@ var InputQuestionTemplate = `
 {{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
 {{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
 {{- color "default+hb"}}{{ .Message }} {{color "reset"}}
-{{- if .Answer}}
+{{- if .ShowAnswer}}
   {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
   {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}} {{end}}
@@ -77,6 +78,6 @@ func (i *Input) Prompt(rl *readline.Instance) (line interface{}, err error) {
 func (i *Input) Cleanup(rl *readline.Instance, val interface{}) error {
 	return i.Render(
 		InputQuestionTemplate,
-		InputTemplateData{Input: *i, Answer: val.(string)},
+		InputTemplateData{Input: *i, Answer: val.(string), ShowAnswer: true},
 	)
 }

--- a/input_test.go
+++ b/input_test.go
@@ -37,7 +37,7 @@ func TestInputRender(t *testing.T) {
 		{
 			"Test Input answer output",
 			Input{Message: "What is your favorite month:"},
-			InputTemplateData{Answer: "October"},
+			InputTemplateData{Answer: "October", ShowAnswer: true},
 			"? What is your favorite month: October\n",
 		},
 		{

--- a/multiselect.go
+++ b/multiselect.go
@@ -27,6 +27,7 @@ type MultiSelect struct {
 type MultiSelectTemplateData struct {
 	MultiSelect
 	Answer        string
+	ShowAnswer    bool
 	Checked       map[int]bool
 	SelectedIndex int
 	ShowHelp      bool
@@ -36,7 +37,7 @@ var MultiSelectQuestionTemplate = `
 {{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
 {{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
 {{- color "default+hb"}}{{ .Message }}{{color "reset"}}
-{{- if .Answer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
+{{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
   {{- if and .Help (not .ShowHelp)}} {{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}}{{end}}
   {{- "\n"}}
@@ -163,6 +164,7 @@ func (m *MultiSelect) Cleanup(rl *readline.Instance, val interface{}) error {
 			SelectedIndex: m.selectedIndex,
 			Checked:       m.checked,
 			Answer:        strings.Join(val.([]string), ", "),
+			ShowAnswer:    true,
 		},
 	)
 }

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -45,7 +45,7 @@ func TestMultiSelectRender(t *testing.T) {
 		{
 			"Test MultiSelect answer output",
 			prompt,
-			MultiSelectTemplateData{Answer: "foo, buz"},
+			MultiSelectTemplateData{Answer: "foo, buz", ShowAnswer: true},
 			"? Pick your words: foo, buz\n",
 		},
 		{

--- a/select.go
+++ b/select.go
@@ -27,6 +27,7 @@ type SelectTemplateData struct {
 	Select
 	SelectedIndex int
 	Answer        string
+	ShowAnswer    bool
 	ShowHelp      bool
 }
 
@@ -34,7 +35,7 @@ var SelectQuestionTemplate = `
 {{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
 {{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
 {{- color "default+hb"}}{{ .Message }}{{color "reset"}}
-{{- if .Answer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
+{{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else}}
   {{- if and .Help (not .ShowHelp)}} {{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}}{{end}}
   {{- "\n"}}
@@ -148,6 +149,6 @@ func (s *Select) Prompt(rl *readline.Instance) (interface{}, error) {
 func (s *Select) Cleanup(rl *readline.Instance, val interface{}) error {
 	return s.Render(
 		SelectQuestionTemplate,
-		SelectTemplateData{Select: *s, Answer: val.(string)},
+		SelectTemplateData{Select: *s, Answer: val.(string), ShowAnswer: true},
 	)
 }

--- a/select_test.go
+++ b/select_test.go
@@ -45,7 +45,7 @@ func TestSelectRender(t *testing.T) {
 		{
 			"Test Select answer output",
 			prompt,
-			SelectTemplateData{Answer: "buz"},
+			SelectTemplateData{Answer: "buz", ShowAnswer: true},
 			"? Pick your word: buz\n",
 		},
 		{


### PR DESCRIPTION
This PR fixes a bug reported in #56 which was causing an issue when `Inputs` were cleaning up without a default value.