### PR TITLE
add Help to Password prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ validators include:
 
 ## Help Text
 
-All of the prompts (except `Password`) have a `Help` field which can be defined to provide more information to your users:
+All of the prompts have a `Help` field which can be defined to provide more information to your users:
 
 <img src="https://media.giphy.com/media/l1KVbc5CehW6r7pss/giphy.gif" width="400px" style="margin-top: 8px"/>
 

--- a/password.go
+++ b/password.go
@@ -44,7 +44,8 @@ func (p *Password) Prompt() (line interface{}, err error) {
 
 	// no help msg?  Just return any response
 	if p.Help == "" {
-		return rr.ReadLine('*')
+		line, err := rr.ReadLine('*')
+		return string(line), err
 	}
 
 	// process answers looking for help prompt answer

--- a/password_test.go
+++ b/password_test.go
@@ -14,26 +14,38 @@ func init() {
 
 func TestPasswordRender(t *testing.T) {
 
-	prompt := Password{
-		Message: "Tell me your secret:",
-	}
-
 	tests := []struct {
 		title    string
 		prompt   Password
+		data     PasswordTemplateData
 		expected string
 	}{
 		{
 			"Test Password question output",
-			prompt,
+			Password{Message: "Tell me your secret:"},
+			PasswordTemplateData{},
 			"? Tell me your secret: ",
+		},
+		{
+			"Test Password question output with help hidden",
+			Password{Message: "Tell me your secret:", Help: "This is helpful"},
+			PasswordTemplateData{},
+			"? Tell me your secret: [? for help] ",
+		},
+		{
+			"Test Password question output with help shown",
+			Password{Message: "Tell me your secret:", Help: "This is helpful"},
+			PasswordTemplateData{ShowHelp: true},
+			`ⓘ This is helpful
+? Tell me your secret: `,
 		},
 	}
 
 	for _, test := range tests {
+		test.data.Password = test.prompt
 		actual, err := core.RunTemplate(
 			PasswordQuestionTemplate,
-			&test.prompt,
+			&test.data,
 		)
 		assert.Nil(t, err, test.title)
 		assert.Equal(t, test.expected, actual, test.title)

--- a/tests/help.go
+++ b/tests/help.go
@@ -10,6 +10,7 @@ var (
 	inputAns       = ""
 	multiselectAns = []string{}
 	selectAns      = ""
+	passwordAns    = ""
 )
 
 var goodTable = []TestUtil.TestTableEntry{
@@ -40,6 +41,12 @@ var goodTable = []TestUtil.TestTableEntry{
 			Options: []string{"red", "blue", "green"},
 			Default: "blue",
 		}, &selectAns,
+	},
+	{
+		"password", &survey.Password{
+			Message: "Enter a secret:",
+			Help:    "Don't really enter a secret, this is just for testing",
+		}, &passwordAns,
 	},
 }
 

--- a/tests/password.go
+++ b/tests/password.go
@@ -9,10 +9,13 @@ var value = ""
 
 var table = []TestUtil.TestTableEntry{
 	{
-		"standard", &survey.Password{"Please type your password:"}, &value,
+		"standard", &survey.Password{Message: "Please type your password:"}, &value,
 	},
 	{
-		"please make sure paste works", &survey.Password{"Please paste your password:"}, &value,
+		"please make sure paste works", &survey.Password{Message: "Please paste your password:"}, &value,
+	},
+	{
+		"no help, send '?'", &survey.Password{Message: "Please type your password:"}, &value,
 	},
 }
 


### PR DESCRIPTION
Change should look pretty familar, mostly just copy/paste from Input to allow for Help.  Had to change the template data type to allow for ShowHelp field.