### PR TITLE
cleanup error message on repeated validation failures

### DIFF
--- a/confirm_test.go
+++ b/confirm_test.go
@@ -2,7 +2,6 @@ package survey
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/AlecAivazis/survey/core"
@@ -17,7 +16,6 @@ func init() {
 
 func TestConfirmRender(t *testing.T) {
 
-	testError := fmt.Errorf("TEST")
 	tests := []struct {
 		title    string
 		prompt   Confirm
@@ -41,14 +39,6 @@ func TestConfirmRender(t *testing.T) {
 			Confirm{Message: "Is pizza your favorite food?"},
 			ConfirmTemplateData{Answer: "Yes"},
 			"? Is pizza your favorite food? Yes\n",
-		},
-		{
-			"Test Confirm error output",
-			Confirm{Message: "Is pizza your favorite food?"},
-			ConfirmTemplateData{Answer: "Yes", Error: &testError},
-			`✘ Sorry, your reply was invalid: TEST
-? Is pizza your favorite food? Yes
-`,
 		},
 		{
 			"Test Confirm with help but help message is hidden",

--- a/core/renderer.go
+++ b/core/renderer.go
@@ -7,20 +7,44 @@ import (
 )
 
 type Renderer struct {
-	lineCount int
-	mask      rune
+	lineCount      int
+	errorLineCount int
 }
 
-func (r *Renderer) Render(tmpl string, data interface{}) error {
+var ErrorTemplate = `{{color "red"}}{{ ErrorIcon }} Sorry, your reply was invalid: {{.Error}}{{color "reset"}}
+`
+
+func (r *Renderer) Error(invalid error) error {
+	// since errors are printed on top we need to reset the prompt
+	// as well as any previous error print
+	r.resetPrompt(r.lineCount + r.errorLineCount)
+	// we just cleared the prompt lines
+	r.lineCount = 0
+	out, err := RunTemplate(ErrorTemplate, invalid)
+	if err != nil {
+		return err
+	}
+	// keep track of how many lines are printed so we can clean up later
+	r.errorLineCount = strings.Count(out, "\n")
+
+	// send the message to the user
+	terminal.Print(out)
+	return nil
+}
+
+func (r *Renderer) resetPrompt(lines int) {
 	// clean out current line in case tmpl didnt end in newline
 	terminal.CursorHorizontalAbsolute(0)
 	terminal.EraseLine(terminal.ERASE_LINE_ALL)
 	// clean up what we left behind last time
-	for i := 0; i < r.lineCount; i++ {
+	for i := 0; i < lines; i++ {
 		terminal.CursorPreviousLine(1)
 		terminal.EraseLine(terminal.ERASE_LINE_ALL)
 	}
+}
 
+func (r *Renderer) Render(tmpl string, data interface{}) error {
+	r.resetPrompt(r.lineCount)
 	// render the template summarizing the current state
 	out, err := RunTemplate(tmpl, data)
 	if err != nil {

--- a/survey_test.go
+++ b/survey_test.go
@@ -17,7 +17,7 @@ func TestValidationError(t *testing.T) {
 	err := fmt.Errorf("Football is not a valid month")
 
 	actual, err := core.RunTemplate(
-		ErrorTemplate,
+		core.ErrorTemplate,
 		err,
 	)
 	if err != nil {

--- a/tests/autoplay/ask.go
+++ b/tests/autoplay/ask.go
@@ -1,4 +1,3 @@
-
 ////////////////////////////////////////////////////////////////////////////////
 //                          DO NOT MODIFY THIS FILE!
 //
@@ -11,18 +10,19 @@
 package main
 
 import (
-    "bufio"
-    "fmt"
-    "os"
-    "os/exec"
-    "strconv"
-    "strings"
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
 	"github.com/kr/pty"
 )
 
 const (
-    RED   = "\033[31m"
-    RESET = "\033[0m"
+	RED   = "\033[31m"
+	RESET = "\033[0m"
 )
 
 func main() {
@@ -115,7 +115,7 @@ func main() {
 	expect("\x1b[0G\x1b[2K\x1b[1;92m? \x1b[0m\x1b[1;99mWhat is your name? \x1b[0m", buf)
 	fh.Write([]byte("\r"))
 	expect("\r\r\n", buf)
-	expect("\x1b[1F\x1b[31m✘ Sorry, your reply was invalid: Value is required\x1b[0m\r\n", buf)
+	expect("\x1b[1F\x1b[0G\x1b[2K\x1b[31m✘ Sorry, your reply was invalid: Value is required\x1b[0m\r\n", buf)
 	expect("\x1b[0G\x1b[2K\x1b[1;92m? \x1b[0m\x1b[1;99mWhat is your name? \x1b[0m", buf)
 	fh.Write([]byte("L"))
 	expect("L", buf)
@@ -153,29 +153,29 @@ func expect(expected string, buf *bufio.Reader) {
 		got, _, _ := buf.ReadRune()
 		sofar = append(sofar, got)
 		if got != r {
-            fmt.Fprintln(os.Stderr, RESET)
+			fmt.Fprintln(os.Stderr, RESET)
 
-            // we want to quote the string but we also want to make the unexpected character RED
-            // so we use the strconv.Quote function but trim off the quoted characters so we can 
-            // merge multiple quoted strings into one.
-            expStart := strings.TrimSuffix(strconv.Quote(expected[:len(sofar)-1]), "\"")
-            expMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(expected[len(sofar)-1])), "\""), "\"")
-            expEnd := strings.TrimPrefix(strconv.Quote(expected[len(sofar):]), "\"")
+			// we want to quote the string but we also want to make the unexpected character RED
+			// so we use the strconv.Quote function but trim off the quoted characters so we can
+			// merge multiple quoted strings into one.
+			expStart := strings.TrimSuffix(strconv.Quote(expected[:len(sofar)-1]), "\"")
+			expMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(expected[len(sofar)-1])), "\""), "\"")
+			expEnd := strings.TrimPrefix(strconv.Quote(expected[len(sofar):]), "\"")
 
-            fmt.Fprintf(os.Stderr, "Expected: %s%s%s%s%s\n", expStart, RED, expMiss, RESET, expEnd)
+			fmt.Fprintf(os.Stderr, "Expected: %s%s%s%s%s\n", expStart, RED, expMiss, RESET, expEnd)
 
-            // read the rest of the buffer
-            p := make([]byte, buf.Buffered())
-            buf.Read(p)
+			// read the rest of the buffer
+			p := make([]byte, buf.Buffered())
+			buf.Read(p)
 
-            gotStart := strings.TrimSuffix(strconv.Quote(string(sofar[:len(sofar)-1])), "\"")
-            gotMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(sofar[len(sofar)-1])), "\""), "\"")
-            gotEnd := strings.TrimPrefix(strconv.Quote(string(p)), "\"")
+			gotStart := strings.TrimSuffix(strconv.Quote(string(sofar[:len(sofar)-1])), "\"")
+			gotMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(sofar[len(sofar)-1])), "\""), "\"")
+			gotEnd := strings.TrimPrefix(strconv.Quote(string(p)), "\"")
 
-            fmt.Fprintf(os.Stderr, "Got:      %s%s%s%s%s\n", gotStart, RED, gotMiss, RESET, gotEnd)
-            panic(fmt.Errorf("Unexpected Rune %q, Expected %q\n", got, r))
-        } else {
-            fmt.Printf("%c", r)
-        }
+			fmt.Fprintf(os.Stderr, "Got:      %s%s%s%s%s\n", gotStart, RED, gotMiss, RESET, gotEnd)
+			panic(fmt.Errorf("Unexpected Rune %q, Expected %q\n", got, r))
+		} else {
+			fmt.Printf("%c", r)
+		}
 	}
 }

--- a/tests/autoplay/ask.go
+++ b/tests/autoplay/ask.go
@@ -1,3 +1,4 @@
+
 ////////////////////////////////////////////////////////////////////////////////
 //                          DO NOT MODIFY THIS FILE!
 //
@@ -10,19 +11,18 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
-
+    "bufio"
+    "fmt"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
 	"github.com/kr/pty"
 )
 
 const (
-	RED   = "\033[31m"
-	RESET = "\033[0m"
+    RED   = "\033[31m"
+    RESET = "\033[0m"
 )
 
 func main() {
@@ -153,29 +153,29 @@ func expect(expected string, buf *bufio.Reader) {
 		got, _, _ := buf.ReadRune()
 		sofar = append(sofar, got)
 		if got != r {
-			fmt.Fprintln(os.Stderr, RESET)
+            fmt.Fprintln(os.Stderr, RESET)
 
-			// we want to quote the string but we also want to make the unexpected character RED
-			// so we use the strconv.Quote function but trim off the quoted characters so we can
-			// merge multiple quoted strings into one.
-			expStart := strings.TrimSuffix(strconv.Quote(expected[:len(sofar)-1]), "\"")
-			expMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(expected[len(sofar)-1])), "\""), "\"")
-			expEnd := strings.TrimPrefix(strconv.Quote(expected[len(sofar):]), "\"")
+            // we want to quote the string but we also want to make the unexpected character RED
+            // so we use the strconv.Quote function but trim off the quoted characters so we can 
+            // merge multiple quoted strings into one.
+            expStart := strings.TrimSuffix(strconv.Quote(expected[:len(sofar)-1]), "\"")
+            expMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(expected[len(sofar)-1])), "\""), "\"")
+            expEnd := strings.TrimPrefix(strconv.Quote(expected[len(sofar):]), "\"")
 
-			fmt.Fprintf(os.Stderr, "Expected: %s%s%s%s%s\n", expStart, RED, expMiss, RESET, expEnd)
+            fmt.Fprintf(os.Stderr, "Expected: %s%s%s%s%s\n", expStart, RED, expMiss, RESET, expEnd)
 
-			// read the rest of the buffer
-			p := make([]byte, buf.Buffered())
-			buf.Read(p)
+            // read the rest of the buffer
+            p := make([]byte, buf.Buffered())
+            buf.Read(p)
 
-			gotStart := strings.TrimSuffix(strconv.Quote(string(sofar[:len(sofar)-1])), "\"")
-			gotMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(sofar[len(sofar)-1])), "\""), "\"")
-			gotEnd := strings.TrimPrefix(strconv.Quote(string(p)), "\"")
+            gotStart := strings.TrimSuffix(strconv.Quote(string(sofar[:len(sofar)-1])), "\"")
+            gotMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(sofar[len(sofar)-1])), "\""), "\"")
+            gotEnd := strings.TrimPrefix(strconv.Quote(string(p)), "\"")
 
-			fmt.Fprintf(os.Stderr, "Got:      %s%s%s%s%s\n", gotStart, RED, gotMiss, RESET, gotEnd)
-			panic(fmt.Errorf("Unexpected Rune %q, Expected %q\n", got, r))
-		} else {
-			fmt.Printf("%c", r)
-		}
+            fmt.Fprintf(os.Stderr, "Got:      %s%s%s%s%s\n", gotStart, RED, gotMiss, RESET, gotEnd)
+            panic(fmt.Errorf("Unexpected Rune %q, Expected %q\n", got, r))
+        } else {
+            fmt.Printf("%c", r)
+        }
 	}
 }

--- a/tests/autoplay/confirm.go
+++ b/tests/autoplay/confirm.go
@@ -1,4 +1,3 @@
-
 ////////////////////////////////////////////////////////////////////////////////
 //                          DO NOT MODIFY THIS FILE!
 //
@@ -11,18 +10,19 @@
 package main
 
 import (
-    "bufio"
-    "fmt"
-    "os"
-    "os/exec"
-    "strconv"
-    "strings"
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
 	"github.com/kr/pty"
 )
 
 const (
-    RED   = "\033[31m"
-    RESET = "\033[0m"
+	RED   = "\033[31m"
+	RESET = "\033[0m"
 )
 
 func main() {
@@ -74,10 +74,10 @@ func main() {
 	fh.Write([]byte("\r"))
 	expect("\r\r\n", buf)
 	expect("\x1b[1F\x1b[0G\x1b[2K\x1b[31m✘ Sorry, your reply was invalid: \"x\" is not a valid answer, please try again.\x1b[0m\r\n", buf)
-	expect("\x1b[1;92m? \x1b[0m\x1b[1;99myes: \x1b[0m\x1b[37m(Y/n) \x1b[0m", buf)
+	expect("\x1b[0G\x1b[2K\x1b[1;92m? \x1b[0m\x1b[1;99myes: \x1b[0m\x1b[37m(Y/n) \x1b[0m", buf)
 	fh.Write([]byte("\r"))
 	expect("\r\r\n", buf)
-	expect("\x1b[1F\x1b[0G\x1b[2K\x1b[1F\x1b[2K\x1b[1;92m? \x1b[0m\x1b[1;99myes: \x1b[0m\x1b[36mYes\x1b[0m\r\n", buf)
+	expect("\x1b[1F\x1b[0G\x1b[2K\x1b[1;92m? \x1b[0m\x1b[1;99myes: \x1b[0m\x1b[36mYes\x1b[0m\r\n", buf)
 	expect("Answered true.\r\n", buf)
 	expect("---------------------\r\n", buf)
 	expect("no help - type '?'\r\n", buf)
@@ -87,10 +87,10 @@ func main() {
 	fh.Write([]byte("\r"))
 	expect("\r\r\n", buf)
 	expect("\x1b[1F\x1b[0G\x1b[2K\x1b[31m✘ Sorry, your reply was invalid: \"?\" is not a valid answer, please try again.\x1b[0m\r\n", buf)
-	expect("\x1b[1;92m? \x1b[0m\x1b[1;99myes: \x1b[0m\x1b[37m(Y/n) \x1b[0m", buf)
+	expect("\x1b[0G\x1b[2K\x1b[1;92m? \x1b[0m\x1b[1;99myes: \x1b[0m\x1b[37m(Y/n) \x1b[0m", buf)
 	fh.Write([]byte("\r"))
 	expect("\r\r\n", buf)
-	expect("\x1b[1F\x1b[0G\x1b[2K\x1b[1F\x1b[2K\x1b[1;92m? \x1b[0m\x1b[1;99myes: \x1b[0m\x1b[36mYes\x1b[0m\r\n", buf)
+	expect("\x1b[1F\x1b[0G\x1b[2K\x1b[1;92m? \x1b[0m\x1b[1;99myes: \x1b[0m\x1b[36mYes\x1b[0m\r\n", buf)
 	expect("Answered true.\r\n", buf)
 	expect("---------------------\r\n", buf)
 
@@ -105,29 +105,29 @@ func expect(expected string, buf *bufio.Reader) {
 		got, _, _ := buf.ReadRune()
 		sofar = append(sofar, got)
 		if got != r {
-            fmt.Fprintln(os.Stderr, RESET)
+			fmt.Fprintln(os.Stderr, RESET)
 
-            // we want to quote the string but we also want to make the unexpected character RED
-            // so we use the strconv.Quote function but trim off the quoted characters so we can 
-            // merge multiple quoted strings into one.
-            expStart := strings.TrimSuffix(strconv.Quote(expected[:len(sofar)-1]), "\"")
-            expMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(expected[len(sofar)-1])), "\""), "\"")
-            expEnd := strings.TrimPrefix(strconv.Quote(expected[len(sofar):]), "\"")
+			// we want to quote the string but we also want to make the unexpected character RED
+			// so we use the strconv.Quote function but trim off the quoted characters so we can
+			// merge multiple quoted strings into one.
+			expStart := strings.TrimSuffix(strconv.Quote(expected[:len(sofar)-1]), "\"")
+			expMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(expected[len(sofar)-1])), "\""), "\"")
+			expEnd := strings.TrimPrefix(strconv.Quote(expected[len(sofar):]), "\"")
 
-            fmt.Fprintf(os.Stderr, "Expected: %s%s%s%s%s\n", expStart, RED, expMiss, RESET, expEnd)
+			fmt.Fprintf(os.Stderr, "Expected: %s%s%s%s%s\n", expStart, RED, expMiss, RESET, expEnd)
 
-            // read the rest of the buffer
-            p := make([]byte, buf.Buffered())
-            buf.Read(p)
+			// read the rest of the buffer
+			p := make([]byte, buf.Buffered())
+			buf.Read(p)
 
-            gotStart := strings.TrimSuffix(strconv.Quote(string(sofar[:len(sofar)-1])), "\"")
-            gotMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(sofar[len(sofar)-1])), "\""), "\"")
-            gotEnd := strings.TrimPrefix(strconv.Quote(string(p)), "\"")
+			gotStart := strings.TrimSuffix(strconv.Quote(string(sofar[:len(sofar)-1])), "\"")
+			gotMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(sofar[len(sofar)-1])), "\""), "\"")
+			gotEnd := strings.TrimPrefix(strconv.Quote(string(p)), "\"")
 
-            fmt.Fprintf(os.Stderr, "Got:      %s%s%s%s%s\n", gotStart, RED, gotMiss, RESET, gotEnd)
-            panic(fmt.Errorf("Unexpected Rune %q, Expected %q\n", got, r))
-        } else {
-            fmt.Printf("%c", r)
-        }
+			fmt.Fprintf(os.Stderr, "Got:      %s%s%s%s%s\n", gotStart, RED, gotMiss, RESET, gotEnd)
+			panic(fmt.Errorf("Unexpected Rune %q, Expected %q\n", got, r))
+		} else {
+			fmt.Printf("%c", r)
+		}
 	}
 }

--- a/tests/autoplay/confirm.go
+++ b/tests/autoplay/confirm.go
@@ -1,3 +1,4 @@
+
 ////////////////////////////////////////////////////////////////////////////////
 //                          DO NOT MODIFY THIS FILE!
 //
@@ -10,19 +11,18 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
-
+    "bufio"
+    "fmt"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
 	"github.com/kr/pty"
 )
 
 const (
-	RED   = "\033[31m"
-	RESET = "\033[0m"
+    RED   = "\033[31m"
+    RESET = "\033[0m"
 )
 
 func main() {
@@ -105,29 +105,29 @@ func expect(expected string, buf *bufio.Reader) {
 		got, _, _ := buf.ReadRune()
 		sofar = append(sofar, got)
 		if got != r {
-			fmt.Fprintln(os.Stderr, RESET)
+            fmt.Fprintln(os.Stderr, RESET)
 
-			// we want to quote the string but we also want to make the unexpected character RED
-			// so we use the strconv.Quote function but trim off the quoted characters so we can
-			// merge multiple quoted strings into one.
-			expStart := strings.TrimSuffix(strconv.Quote(expected[:len(sofar)-1]), "\"")
-			expMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(expected[len(sofar)-1])), "\""), "\"")
-			expEnd := strings.TrimPrefix(strconv.Quote(expected[len(sofar):]), "\"")
+            // we want to quote the string but we also want to make the unexpected character RED
+            // so we use the strconv.Quote function but trim off the quoted characters so we can 
+            // merge multiple quoted strings into one.
+            expStart := strings.TrimSuffix(strconv.Quote(expected[:len(sofar)-1]), "\"")
+            expMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(expected[len(sofar)-1])), "\""), "\"")
+            expEnd := strings.TrimPrefix(strconv.Quote(expected[len(sofar):]), "\"")
 
-			fmt.Fprintf(os.Stderr, "Expected: %s%s%s%s%s\n", expStart, RED, expMiss, RESET, expEnd)
+            fmt.Fprintf(os.Stderr, "Expected: %s%s%s%s%s\n", expStart, RED, expMiss, RESET, expEnd)
 
-			// read the rest of the buffer
-			p := make([]byte, buf.Buffered())
-			buf.Read(p)
+            // read the rest of the buffer
+            p := make([]byte, buf.Buffered())
+            buf.Read(p)
 
-			gotStart := strings.TrimSuffix(strconv.Quote(string(sofar[:len(sofar)-1])), "\"")
-			gotMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(sofar[len(sofar)-1])), "\""), "\"")
-			gotEnd := strings.TrimPrefix(strconv.Quote(string(p)), "\"")
+            gotStart := strings.TrimSuffix(strconv.Quote(string(sofar[:len(sofar)-1])), "\"")
+            gotMiss := strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(string(sofar[len(sofar)-1])), "\""), "\"")
+            gotEnd := strings.TrimPrefix(strconv.Quote(string(p)), "\"")
 
-			fmt.Fprintf(os.Stderr, "Got:      %s%s%s%s%s\n", gotStart, RED, gotMiss, RESET, gotEnd)
-			panic(fmt.Errorf("Unexpected Rune %q, Expected %q\n", got, r))
-		} else {
-			fmt.Printf("%c", r)
-		}
+            fmt.Fprintf(os.Stderr, "Got:      %s%s%s%s%s\n", gotStart, RED, gotMiss, RESET, gotEnd)
+            panic(fmt.Errorf("Unexpected Rune %q, Expected %q\n", got, r))
+        } else {
+            fmt.Printf("%c", r)
+        }
 	}
 }


### PR DESCRIPTION
This is a fix for #62 to allow prompts to clean up previous error messages on repeated failed validations.

It basically adds an `Error(error) error` function to the `Prompt` interface which is implemented via the `renderer` common base composed class.
