### PR TITLE
allow for settable interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ survey.AskOne(
     &myval,
     nil,
 )
+// myval.value should be populated with the prompt result now.
 ```
 
 If you want to capture the name associated with the prompt you can use this form:
@@ -208,7 +209,8 @@ func (my *MyMapValue) WriteAnswerField(name string, value interface{}) error {
 mymap := MyMapValue{value: make(map[string]string)}
 // qs defined in previous examples
 survey.Ask(qs, &mymap)
-// mymap.value["name"] and mymap.value["color"] should populated now
+// mymap.value["name"] and mymap.value["color"] should be populated with
+// the corresponding prompt results now.
 ```
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ func main() {
     1. [Confirm](#confirm)
     1. [Select](#select)
     1. [MultiSelect](#multiselect)
+1. [Custom Types](#custom-types)
 1. [Validation](#validation)
     1. [Built-in Validators](#built-in-validators)
 1. [Help Text](#help-text)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,54 @@ change the global `survey.PageCount`, or set the `PageSize` field on the prompt:
 prompt := &survey.MultiSelect{..., PageSize: 10}
 ```
 
+## Custom Types
+
+survey will assign prompt answers to your custom types if they implement one of these interfaces:
+```
+type settable interface {
+    WriteAnswer(value interface{}) error
+}
+```
+```
+type fieldsettable interface {
+    WriteAnswerField(field string, value interface{}) error
+}
+```
+
+Here is an example how to use them:
+```
+type MyValue struct {
+    value string
+}
+func (my *MyValue) WriteAnswer(value interface{}) error {
+     my.value = value.(string)
+}
+
+myval := MyValue{}
+survey.AskOne(
+    &survey.Input{
+        Message: "Enter something:",
+    },
+    &myval,
+    nil,
+)
+```
+
+If you want to capture the name associated with the prompt you can use this form:
+```
+type MyMapValue struct {
+    value map[string]string
+}
+func (my *MyMapValue) WriteAnswerField(name string, value interface{}) error {
+     my.value[name] = value.(string)
+}
+
+mymap := MyMapValue{value: make(map[string]string)}
+// qs defined in previous examples
+survey.Ask(qs, &mymap)
+// mymap.value["name"] and mymap.value["color"] should populated now
+```
+
 ## Validation
 
 Validating individual responses for a particular question can be done by defining a

--- a/core/write.go
+++ b/core/write.go
@@ -10,7 +10,24 @@ import (
 // the tag used to denote the name of the question
 const tagName = "survey"
 
+// add a few interfaces so users can configure how the prompt values are set
+type settable interface {
+	Set(value interface{}) error
+}
+
+type fieldsettable interface {
+	SetField(field string, value interface{}) error
+}
+
 func WriteAnswer(t interface{}, name string, v interface{}) (err error) {
+
+	if s, ok := t.(settable); ok {
+		return s.Set(v)
+	}
+	if fs, ok := t.(fieldsettable); ok {
+		return fs.SetField(name, v)
+	}
+
 	// the target to write to
 	target := reflect.ValueOf(t)
 	// the value to write from

--- a/core/write.go
+++ b/core/write.go
@@ -12,20 +12,20 @@ const tagName = "survey"
 
 // add a few interfaces so users can configure how the prompt values are set
 type settable interface {
-	Set(value interface{}) error
+	WriteAnswer(value interface{}) error
 }
 
 type fieldsettable interface {
-	SetField(field string, value interface{}) error
+	WriteAnswerField(field string, value interface{}) error
 }
 
 func WriteAnswer(t interface{}, name string, v interface{}) (err error) {
 
 	if s, ok := t.(settable); ok {
-		return s.Set(v)
+		return s.WriteAnswer(v)
 	}
 	if fs, ok := t.(fieldsettable); ok {
-		return fs.SetField(name, v)
+		return fs.WriteAnswerField(name, v)
 	}
 
 	// the target to write to

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -256,7 +256,7 @@ type testSettable struct {
 	Value string
 }
 
-func (t *testSettable) Set(value interface{}) error {
+func (t *testSettable) WriteAnswer(value interface{}) error {
 	if v, ok := value.(string); ok {
 		t.Value = v
 		return nil
@@ -280,7 +280,7 @@ type testFieldSettable struct {
 	Values map[string]string
 }
 
-func (t *testFieldSettable) SetField(name string, value interface{}) error {
+func (t *testFieldSettable) WriteAnswerField(name string, value interface{}) error {
 	if t.Values == nil {
 		t.Values = map[string]string{}
 	}


### PR DESCRIPTION
This is a little abstract, but it will allow for the users to be able to control how assignment is done to custom types via the survey.Ask routines, something along the lines of:

```
survey.AskOne(
    &survey.Input{
        Message: "Enter something:",
   },
   &myCustomType,
   nil,
)
```

This patch allows me to implement: `Set(value interface{}) error` or `SetField(name string, value interface{}) error` on my custom type to perform the assignments.  

I was working on refactoring a large project that uses `survey` and ran into problems as a `string` was assigned to `MyCustomType` via the `core.copy` routine. 
