### PR TITLE
Enable converting from prompt response to primitive types

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -1,0 +1,53 @@
+package survey
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/AlecAivazis/survey/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	// disable color output for all prompts to simplify testing
+	core.DisableColor = true
+}
+
+func TestConverter(t *testing.T) {
+	q := []*Question{
+		{
+			Name: "age",
+			Prompt: &Input{
+				Message: "What is your age?",
+			},
+			Validate: Required,
+			Convert: func(val interface{}) (interface{}, error) {
+				newVal, err := strconv.ParseInt(val.(string), 10, 64)
+				if err != nil {
+					return nil, errors.New("please enter a valid integer")
+				}
+
+				return newVal, nil
+			},
+		},
+	}
+
+	in, _ := ioutil.TempFile("", "")
+	defer in.Close()
+
+	os.Stdin = in
+
+	io.WriteString(in, "21\n")
+	in.Seek(0, os.SEEK_SET)
+
+	age := int64(0)
+	err := Ask(q, &age)
+
+	assert.Nil(t, err)
+	assert.Equal(t, int64(21), age)
+
+}

--- a/core/write.go
+++ b/core/write.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -102,6 +103,80 @@ func copy(t reflect.Value, v reflect.Value) (err error) {
 	}()
 
 	// attempt to copy the underlying value to the target
+	if v.Kind() == reflect.String && v.Type() != t.Type() {
+		var castVal interface{}
+		var casterr error
+		vString := v.Interface().(string)
+
+		switch t.Kind() {
+		case reflect.Bool:
+			castVal, casterr = strconv.ParseBool(vString)
+		case reflect.Int:
+			castVal, casterr = strconv.Atoi(vString)
+		case reflect.Int8:
+			var val64 int64
+			val64, casterr = strconv.ParseInt(vString, 10, 8)
+			if casterr == nil {
+				castVal = int8(val64)
+			}
+		case reflect.Int16:
+			var val64 int64
+			val64, casterr = strconv.ParseInt(vString, 10, 16)
+			if casterr == nil {
+				castVal = int16(val64)
+			}
+		case reflect.Int32:
+			var val64 int64
+			val64, casterr = strconv.ParseInt(vString, 10, 32)
+			if casterr == nil {
+				castVal = int32(val64)
+			}
+		case reflect.Int64:
+			castVal, casterr = strconv.ParseInt(vString, 10, 64)
+		case reflect.Uint:
+			var val64 uint64
+			val64, casterr = strconv.ParseUint(vString, 10, 8)
+			if casterr == nil {
+				castVal = uint(val64)
+			}
+		case reflect.Uint8:
+			var val64 uint64
+			val64, casterr = strconv.ParseUint(vString, 10, 8)
+			if casterr == nil {
+				castVal = uint8(val64)
+			}
+		case reflect.Uint16:
+			var val64 uint64
+			val64, casterr = strconv.ParseUint(vString, 10, 16)
+			if casterr == nil {
+				castVal = uint16(val64)
+			}
+		case reflect.Uint32:
+			var val64 uint64
+			val64, casterr = strconv.ParseUint(vString, 10, 32)
+			if casterr == nil {
+				castVal = uint32(val64)
+			}
+		case reflect.Uint64:
+			castVal, casterr = strconv.ParseUint(vString, 10, 64)
+		case reflect.Float32:
+			var val64 float64
+			val64, casterr = strconv.ParseFloat(vString, 32)
+			if casterr == nil {
+				castVal = float32(val64)
+			}
+		case reflect.Float64:
+			castVal, casterr = strconv.ParseFloat(vString, 64)
+		}
+
+		if casterr != nil {
+			return casterr
+		}
+
+		t.Set(reflect.ValueOf(castVal))
+		return
+	}
+
 	t.Set(v)
 
 	// we're done

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -248,3 +248,225 @@ func TestFindFieldIndex_tagOverwriteFieldName(t *testing.T) {
 		t.Errorf("Did not find the correct field name. Expected 'Username' found %v.", val.Type().Field(fieldIndex).Name)
 	}
 }
+
+// CONVERSION TESTS
+func TestWrite_canStringToBool(t *testing.T) {
+	// a pointer to hold the boolean value
+	ptr := true
+
+	// try to copy a false value to the pointer
+	WriteAnswer(&ptr, "", "false")
+
+	// if the value is true
+	if ptr {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToInt(t *testing.T) {
+	// a pointer to hold the value
+	var ptr int = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToInt8(t *testing.T) {
+	// a pointer to hold the value
+	var ptr int8 = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToInt16(t *testing.T) {
+	// a pointer to hold the value
+	var ptr int16 = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToInt32(t *testing.T) {
+	// a pointer to hold the value
+	var ptr int32 = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToInt64(t *testing.T) {
+	// a pointer to hold the value
+	var ptr int64 = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToUint(t *testing.T) {
+	// a pointer to hold the value
+	var ptr uint = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToUint8(t *testing.T) {
+	// a pointer to hold the value
+	var ptr uint8 = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToUint16(t *testing.T) {
+	// a pointer to hold the value
+	var ptr uint16 = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToUint32(t *testing.T) {
+	// a pointer to hold the value
+	var ptr uint32 = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToUint64(t *testing.T) {
+	// a pointer to hold the value
+	var ptr uint64 = 1
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2")
+
+	// if the value is true
+	if ptr != 2 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToFloat32(t *testing.T) {
+	// a pointer to hold the value
+	var ptr float32 = 1.0
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2.5")
+
+	// if the value is true
+	if ptr != 2.5 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canStringToFloat64(t *testing.T) {
+	// a pointer to hold the value
+	var ptr float64 = 1.0
+
+	// try to copy a value to the pointer
+	WriteAnswer(&ptr, "", "2.5")
+
+	// if the value is true
+	if ptr != 2.5 {
+		// the test failed
+		t.Error("Could not convert string to pointer type")
+	}
+}
+
+func TestWrite_canConvertStructFieldTypes(t *testing.T) {
+	// the struct to hold the answer
+	ptr := struct {
+		Name   string
+		Age    uint
+		Male   bool
+		Height float64
+	}{}
+
+	// write the values as strings
+	check(t, WriteAnswer(&ptr, "name", "Bob"))
+	check(t, WriteAnswer(&ptr, "age", "22"))
+	check(t, WriteAnswer(&ptr, "male", "true"))
+	check(t, WriteAnswer(&ptr, "height", "6.2"))
+
+	// make sure we changed the fields
+	if ptr.Name != "Bob" {
+		t.Error("Did not mutate Name when writing answer.")
+	}
+
+	if ptr.Age != 22 {
+		t.Error("Did not mutate Age when writing answer.")
+	}
+
+	if !ptr.Male {
+		t.Error("Did not mutate Male when writing answer.")
+	}
+
+	if ptr.Height != 6.2 {
+		t.Error("Did not mutate Height when writing answer.")
+	}
+}
+
+func check(t *testing.T, err error) {
+	if err != nil {
+		t.Fatalf("Encountered error while writing answer: %v", err.Error())
+	}
+}

--- a/survey.go
+++ b/survey.go
@@ -9,11 +9,15 @@ import (
 // Validator is a function passed to a Question in order to redefine
 type Validator func(interface{}) error
 
+// Converter is a function passed to a Question in order to convert value types
+type Converter func(interface{}) (interface{}, error)
+
 // Question is the core data structure for a survey questionnaire.
 type Question struct {
 	Name     string
 	Prompt   Prompt
 	Validate Validator
+	Convert  Converter
 }
 
 // Prompt is the primary interface for the objects that can take user input
@@ -25,8 +29,8 @@ type Prompt interface {
 }
 
 // AskOne asks a single question without performing validation on the answer.
-func AskOne(p Prompt, t interface{}, v Validator) error {
-	err := Ask([]*Question{{Prompt: p, Validate: v}}, t)
+func AskOne(p Prompt, t interface{}, v Validator, c Converter) error {
+	err := Ask([]*Question{{Prompt: p, Validate: v, Convert: c}}, t)
 	if err != nil {
 		return err
 	}
@@ -47,15 +51,37 @@ func Ask(qs []*Question, t interface{}) error {
 	for _, q := range qs {
 		// grab the user input and save it
 		ans, err := q.Prompt.Prompt()
+		convertedAns := ans
 		// if there was a problem
 		if err != nil {
 			return err
 		}
 
+		// if there's a converter
+		if q.Convert != nil {
+			var invalid error
+
+			// wait for a valid response
+			for convertedAns, invalid = q.Convert(ans); invalid != nil; convertedAns, invalid = q.Convert(ans) {
+				err := q.Prompt.Error(invalid)
+				// if there was a problem
+				if err != nil {
+					return err
+				}
+
+				// ask for more input
+				ans, err = q.Prompt.Prompt()
+				// if there was a problem
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		// if there is a validate handler for this question
 		if q.Validate != nil {
 			// wait for a valid response
-			for invalid := q.Validate(ans); invalid != nil; invalid = q.Validate(ans) {
+			for invalid := q.Validate(convertedAns); invalid != nil; invalid = q.Validate(convertedAns) {
 				err := q.Prompt.Error(invalid)
 				// if there was a problem
 				if err != nil {
@@ -81,7 +107,7 @@ func Ask(qs []*Question, t interface{}) error {
 		}
 
 		// add it to the map
-		err = core.WriteAnswer(t, q.Name, ans)
+		err = core.WriteAnswer(t, q.Name, convertedAns)
 		// if something went wrong
 		if err != nil {
 			return err

--- a/tests/ask.go
+++ b/tests/ask.go
@@ -42,7 +42,7 @@ func main() {
 
 	fmt.Println("Asking one.")
 	answer := ""
-	err = survey.AskOne(simpleQs[0].Prompt, &answer, nil)
+	err = survey.AskOne(simpleQs[0].Prompt, &answer, nil, nil)
 	if err != nil {
 		fmt.Println(err.Error())
 		return
@@ -51,7 +51,7 @@ func main() {
 
 	fmt.Println("Asking one with validation.")
 	vAns := ""
-	err = survey.AskOne(&survey.Input{Message: "What is your name?"}, &vAns, survey.Required)
+	err = survey.AskOne(&survey.Input{Message: "What is your name?"}, &vAns, survey.Required, nil)
 	if err != nil {
 		fmt.Println(err.Error())
 		return

--- a/tests/util/test.go
+++ b/tests/util/test.go
@@ -25,7 +25,7 @@ func RunTable(table []TestTableEntry) {
 		// tell the user what we are going to ask them
 		fmt.Println(entry.Name)
 		// perform the ask
-		err := survey.AskOne(entry.Prompt, entry.Value, nil)
+		err := survey.AskOne(entry.Prompt, entry.Value, nil, nil)
 		if err != nil {
 			fmt.Printf("AskOne on %v's prompt failed: %v.", entry.Name, err.Error())
 			break
@@ -41,7 +41,7 @@ func RunErrorTable(table []TestTableEntry) {
 		// tell the user what we are going to ask them
 		fmt.Println(entry.Name)
 		// perform the ask
-		err := survey.AskOne(entry.Prompt, entry.Value, nil)
+		err := survey.AskOne(entry.Prompt, entry.Value, nil, nil)
 		if err == nil {
 			fmt.Printf("AskOne on %v's prompt didn't fail.", entry.Name)
 			break


### PR DESCRIPTION
This PR (thanks to @jdoklovic) allows for easy conversion from the return type of the prompt to the specified one in the given struct. 

I have a few minor things I'd like to change before this is ready, but those should get in pretty quick since all the hard work is already done.

One thign i'd like to do is move the Converter work to a different PR, i think it can be merged in tandem with a `Transform` field that I have been thinking about allowing before values get validated.