### PR TITLE
Refactor/one write interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,23 +171,20 @@ prompt := &survey.MultiSelect{..., PageSize: 10}
 ## Custom Types
 
 survey will assign prompt answers to your custom types if they implement one of these interfaces:
+
 ```golang
 type settable interface {
-    WriteAnswer(value interface{}) error
-}
-```
-```golang
-type fieldsettable interface {
-    WriteAnswerField(field string, value interface{}) error
+    WriteAnswer(field string, value interface{}) error
 }
 ```
 
 Here is an example how to use them:
+
 ```golang
 type MyValue struct {
     value string
 }
-func (my *MyValue) WriteAnswer(value interface{}) error {
+func (my *MyValue) WriteAnswer(name string, value interface{}) error {
      my.value = value.(string)
 }
 
@@ -199,23 +196,6 @@ survey.AskOne(
     &myval,
     nil,
 )
-// myval.value should be populated with the prompt result now.
-```
-
-If you want to capture the name associated with the prompt you can use this form:
-```golang
-type MyMapValue struct {
-    value map[string]string
-}
-func (my *MyMapValue) WriteAnswerField(name string, value interface{}) error {
-     my.value[name] = value.(string)
-}
-
-mymap := MyMapValue{value: make(map[string]string)}
-// qs defined in previous examples
-survey.Ask(qs, &mymap)
-// mymap.value["name"] and mymap.value["color"] should be populated with
-// the corresponding prompt results now.
 ```
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ func main() {
     1. [Confirm](#confirm)
     1. [Select](#select)
     1. [MultiSelect](#multiselect)
-1. [Custom Types](#custom-types)
 1. [Validation](#validation)
     1. [Built-in Validators](#built-in-validators)
 1. [Help Text](#help-text)
     1. [Changing the input rune](#changing-the-input-run)
+1. [Custom Types](#custom-types)
 1. [Customizing Output](#customizing-output)
 1. [Versioning](#versioning)
 
@@ -168,36 +168,6 @@ change the global `survey.PageCount`, or set the `PageSize` field on the prompt:
 prompt := &survey.MultiSelect{..., PageSize: 10}
 ```
 
-## Custom Types
-
-survey will assign prompt answers to your custom types if they implement one of these interfaces:
-
-```golang
-type settable interface {
-    WriteAnswer(field string, value interface{}) error
-}
-```
-
-Here is an example how to use them:
-
-```golang
-type MyValue struct {
-    value string
-}
-func (my *MyValue) WriteAnswer(name string, value interface{}) error {
-     my.value = value.(string)
-}
-
-myval := MyValue{}
-survey.AskOne(
-    &survey.Input{
-        Message: "Enter something:",
-    },
-    &myval,
-    nil,
-)
-```
-
 ## Validation
 
 Validating individual responses for a particular question can be done by defining a
@@ -264,6 +234,35 @@ surveyCore.HelpInputRune = '^'
 survey.AskOne(prompt, &number, nil)
 ```
 
+## Custom Types
+
+survey will assign prompt answers to your custom types if they implement one of these interfaces:
+
+```golang
+type settable interface {
+    WriteAnswer(field string, value interface{}) error
+}
+```
+
+Here is an example how to use them:
+
+```golang
+type MyValue struct {
+    value string
+}
+func (my *MyValue) WriteAnswer(name string, value interface{}) error {
+     my.value = value.(string)
+}
+
+myval := MyValue{}
+survey.AskOne(
+    &survey.Input{
+        Message: "Enter something:",
+    },
+    &myval,
+    nil,
+)
+```
 
 ## Customizing Output
 

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -256,6 +256,10 @@ type testFieldSettable struct {
 	Values map[string]string
 }
 
+type testTaggedStruct struct {
+	TaggedValue string `survey:"tagged"`
+}
+
 func (t *testFieldSettable) WriteAnswer(name string, value interface{}) error {
 	if t.Values == nil {
 		t.Values = map[string]string{}
@@ -277,6 +281,11 @@ func TestWriteWithFieldSettable(t *testing.T) {
 	err = WriteAnswer(&testSet2, "values", 123)
 	assert.Error(t, fmt.Errorf("Incompatible type int64"), err)
 	assert.Equal(t, map[string]string{}, testSet2.Values)
+
+	testSetStruct := testTaggedStruct{}
+	err = WriteAnswer(&testSetStruct, "tagged", "stringVal1")
+	assert.Nil(t, err)
+	assert.Equal(t, testSetStruct.TaggedValue, "stringVal1")
 }
 
 // CONVERSION TESTS

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -252,44 +252,11 @@ func TestFindFieldIndex_tagOverwriteFieldName(t *testing.T) {
 	}
 }
 
-type testSettable struct {
-	Value string
-}
-
-type testSettableStruct struct {
-	Settable testSettable `survey:"settable"`
-}
-
-func (t *testSettable) WriteAnswer(value interface{}) error {
-	if v, ok := value.(string); ok {
-		t.Value = v
-		return nil
-	}
-	return fmt.Errorf("Incompatible type %T", value)
-}
-
-func TestWriteWithSettable(t *testing.T) {
-	testSet1 := testSettable{}
-	err := WriteAnswer(&testSet1, "prompt", "stringVal")
-	assert.Nil(t, err)
-	assert.Equal(t, "stringVal", testSet1.Value)
-
-	testSet2 := testSettable{}
-	err = WriteAnswer(&testSet2, "prompt", 123)
-	assert.Error(t, fmt.Errorf("Incompatible type int64"), err)
-	assert.Equal(t, "", testSet2.Value)
-
-	testSetStruct := testSettableStruct{}
-	err = WriteAnswer(&testSetStruct, "settable", "stringVal1")
-	assert.Nil(t, err)
-	assert.Equal(t, testSetStruct.Settable.Value, "stringVal1")
-}
-
 type testFieldSettable struct {
 	Values map[string]string
 }
 
-func (t *testFieldSettable) WriteAnswerField(name string, value interface{}) error {
+func (t *testFieldSettable) WriteAnswer(name string, value interface{}) error {
 	if t.Values == nil {
 		t.Values = map[string]string{}
 	}
@@ -302,12 +269,12 @@ func (t *testFieldSettable) WriteAnswerField(name string, value interface{}) err
 
 func TestWriteWithFieldSettable(t *testing.T) {
 	testSet1 := testFieldSettable{}
-	err := WriteAnswer(&testSet1, "prompt", "stringVal")
+	err := WriteAnswer(&testSet1, "values", "stringVal")
 	assert.Nil(t, err)
-	assert.Equal(t, map[string]string{"prompt": "stringVal"}, testSet1.Values)
+	assert.Equal(t, map[string]string{"values": "stringVal"}, testSet1.Values)
 
 	testSet2 := testFieldSettable{}
-	err = WriteAnswer(&testSet2, "prompt", 123)
+	err = WriteAnswer(&testSet2, "values", 123)
 	assert.Error(t, fmt.Errorf("Incompatible type int64"), err)
 	assert.Equal(t, map[string]string{}, testSet2.Values)
 }


### PR DESCRIPTION
This PR merges the write interfaces into a single one with `WriteAnswer(name string, value interface{}`) in order to simplify the overall API.

Part of me thinks this interface pattern is better suited to be under a `Transform` field on the `survey.Question` but it's hard for me to know why that feels more right. I guess the interface feels a bit like unnecessary boilerplate in order to change one value to another. What do you think?

If we do opt to keep it, I'd like to condense the two interfaces into a single one as I've described above in order to minimize the number of different ways something can be done.