### PR TITLE
fix setting struct members via WriteAnswer interface

### DIFF
--- a/core/write.go
+++ b/core/write.go
@@ -48,9 +48,11 @@ func WriteAnswer(t interface{}, name string, v interface{}) (err error) {
 		}
 		field := elem.Field(fieldIndex)
 		// handle references to the settable interface aswell
-		if s, ok := t.(settable); ok && field.CanAddr() {
-			// use the interface method
-			return s.WriteAnswer(name, v)
+		if field.CanAddr() {
+			if s, ok := field.Addr().Interface().(settable); ok {
+				// use the interface method
+				return s.WriteAnswer(name, v)
+			}
 		}
 
 		// copy the value over to the normal struct

--- a/core/write.go
+++ b/core/write.go
@@ -48,6 +48,10 @@ func WriteAnswer(t interface{}, name string, v interface{}) (err error) {
 		}
 		field := elem.Field(fieldIndex)
 		// handle references to the settable interface aswell
+		if s, ok := field.Interface().(settable); ok {
+			// use the interface method
+			return s.WriteAnswer(name, v)
+		}
 		if field.CanAddr() {
 			if s, ok := field.Addr().Interface().(settable); ok {
 				// use the interface method

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -264,6 +264,10 @@ type testTaggedStruct struct {
 	TaggedValue testStringSettable `survey:"tagged"`
 }
 
+type testPtrTaggedStruct struct {
+	TaggedValue *testStringSettable `survey:"tagged"`
+}
+
 func (t *testFieldSettable) WriteAnswer(name string, value interface{}) error {
 	if t.Values == nil {
 		t.Values = map[string]string{}
@@ -300,6 +304,11 @@ func TestWriteWithFieldSettable(t *testing.T) {
 	err = WriteAnswer(&testSetStruct, "tagged", "stringVal1")
 	assert.Nil(t, err)
 	assert.Equal(t, testTaggedStruct{TaggedValue: testStringSettable{"stringVal1"}}, testSetStruct)
+
+	testPtrSetStruct := testPtrTaggedStruct{&testStringSettable{}}
+	err = WriteAnswer(&testPtrSetStruct, "tagged", "stringVal1")
+	assert.Nil(t, err)
+	assert.Equal(t, testPtrTaggedStruct{TaggedValue: &testStringSettable{"stringVal1"}}, testPtrSetStruct)
 }
 
 // CONVERSION TESTS

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -256,8 +256,12 @@ type testFieldSettable struct {
 	Values map[string]string
 }
 
+type testStringSettable struct {
+	Value string `survey:"string"`
+}
+
 type testTaggedStruct struct {
-	TaggedValue string `survey:"tagged"`
+	TaggedValue testStringSettable `survey:"tagged"`
 }
 
 func (t *testFieldSettable) WriteAnswer(name string, value interface{}) error {
@@ -271,6 +275,11 @@ func (t *testFieldSettable) WriteAnswer(name string, value interface{}) error {
 	return fmt.Errorf("Incompatible type %T", value)
 }
 
+func (t *testStringSettable) WriteAnswer(_ string, value interface{}) error {
+	t.Value = value.(string)
+	return nil
+}
+
 func TestWriteWithFieldSettable(t *testing.T) {
 	testSet1 := testFieldSettable{}
 	err := WriteAnswer(&testSet1, "values", "stringVal")
@@ -282,10 +291,15 @@ func TestWriteWithFieldSettable(t *testing.T) {
 	assert.Error(t, fmt.Errorf("Incompatible type int64"), err)
 	assert.Equal(t, map[string]string{}, testSet2.Values)
 
+	testString1 := testStringSettable{}
+	err = WriteAnswer(&testString1, "", "value1")
+	assert.Nil(t, err)
+	assert.Equal(t, testStringSettable{"value1"}, testString1)
+
 	testSetStruct := testTaggedStruct{}
 	err = WriteAnswer(&testSetStruct, "tagged", "stringVal1")
 	assert.Nil(t, err)
-	assert.Equal(t, testSetStruct.TaggedValue, "stringVal1")
+	assert.Equal(t, testTaggedStruct{TaggedValue: testStringSettable{"stringVal1"}}, testSetStruct)
 }
 
 // CONVERSION TESTS


### PR DESCRIPTION
I missed the refactoring you did to how we set the struct field values via the WriteAnswer interface, unfortunately what you had doesnt work, so have tweaked it and added more tests.  

Several issues:
* you were attempting to set `t` which is the parent object, not the field we want to set
* because it is a field it will typically be a concrete type (not a pointer type) and a pointer type is required to fulfill the `settable` interface, so we have to take the address of the field, but that is now always safe so we have to fence with a CanAddr call.
* added an extra case when the field is already a pointer type then we can just take the Interface directly to verify the settable `interface`