### PR TITLE
[#89] replaced local imports with references to gopkg.in

### DIFF
--- a/.tasks.yml
+++ b/.tasks.yml
@@ -20,4 +20,4 @@ tests:
   command: go test {{.files}}
 
 variables:
-  files: '$(go list -v ./... | grep -iEv "github.com/AlecAivazis/survey/(tests|examples)")'
+  files: '$(go list -v ./... | grep -iEv "gopkg.in/AlecAivazis/survey.v1/(tests|examples)")'

--- a/.tasks.yml
+++ b/.tasks.yml
@@ -20,4 +20,4 @@ tests:
   command: go test {{.files}}
 
 variables:
-  files: '$(go list -v ./... | grep -iEv "gopkg.in/AlecAivazis/survey.v1/(tests|examples)")'
+  files: '$(go list -v ./... | grep -iEv "tests|examples")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
-go_import_path: gopkg.in/alecaivazis/survey.v1
+go_import_path: gopkg.in/AlecAivazis/survey.v1
 
 before_install:
   - go get github.com/AlecAivazis/run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+go_import_path: gopkg.in/alecaivazis/survey.v1
+
 before_install:
   - go get github.com/AlecAivazis/run
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Survey
 [![Build Status](https://travis-ci.org/AlecAivazis/survey.svg?branch=feature%2Fpretty)](https://travis-ci.org/AlecAivazis/survey)
-[![GoDoc](http://img.shields.io/badge/godoc-reference-5272B4.svg)](https://godoc.org/github.com/AlecAivazis/survey)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-5272B4.svg)](https://github.com/AlecAivazis/survey)
 
 A library for building interactive prompts. Heavily inspired by the great [inquirer.js](https://github.com/SBoudrias/Inquirer.js/).
 
@@ -77,7 +77,7 @@ Examples can be found in the `examples/` directory. Run them
 to see basic behavior:
 
 ```bash
-go get github.com/AlecAivazis/survey
+go get gopkg.in/AlecAivazis/survey.v1
 
 # ... navigate to the repo in your GOPATH
 
@@ -280,9 +280,8 @@ in `survey/core`:
 
 ## Versioning
 
-This project tries to maintain semantic GitHub releases as closely as possible. As such, services
-like [gopkg.in](http://labix.org/gopkg.in) work very well to ensure non-breaking changes whenever
-you build your application. For example, importing v1 of survey could look something like
+This project tries to maintain semantic GitHub releases as closely as possible. And relies on [gopkg.in](http://labix.org/gopkg.in)
+to maintain those releasees. Importing v1 of survey could look something like
 
 ```golang
 package main

--- a/confirm.go
+++ b/confirm.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/AlecAivazis/survey/core"
-	"github.com/AlecAivazis/survey/terminal"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 // Confirm is a regular text input that accept yes/no answers. Response type is a bool.

--- a/confirm_test.go
+++ b/confirm_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/AlecAivazis/survey/core"
-	"github.com/AlecAivazis/survey/terminal"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 func init() {

--- a/core/renderer.go
+++ b/core/renderer.go
@@ -3,7 +3,7 @@ package core
 import (
 	"strings"
 
-	"github.com/AlecAivazis/survey/terminal"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 type Renderer struct {

--- a/examples/longlist.go
+++ b/examples/longlist.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/AlecAivazis/survey"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 // the questions to ask

--- a/examples/map.go
+++ b/examples/map.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/AlecAivazis/survey"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 // the questions to ask

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/AlecAivazis/survey"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 // the questions to ask

--- a/examples/validation.go
+++ b/examples/validation.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/AlecAivazis/survey"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 // the questions to ask

--- a/input.go
+++ b/input.go
@@ -3,8 +3,8 @@ package survey
 import (
 	"os"
 
-	"github.com/AlecAivazis/survey/core"
-	"github.com/AlecAivazis/survey/terminal"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 /*

--- a/input_test.go
+++ b/input_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/AlecAivazis/survey/core"
-	"github.com/AlecAivazis/survey/terminal"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 func init() {

--- a/multiselect.go
+++ b/multiselect.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/AlecAivazis/survey/core"
-	"github.com/AlecAivazis/survey/terminal"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 /*

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/AlecAivazis/survey/core"
-	"github.com/AlecAivazis/survey/terminal"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 func init() {

--- a/password.go
+++ b/password.go
@@ -3,8 +3,8 @@ package survey
 import (
 	"os"
 
-	"github.com/AlecAivazis/survey/core"
-	"github.com/AlecAivazis/survey/terminal"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 /*

--- a/password_test.go
+++ b/password_test.go
@@ -3,8 +3,8 @@ package survey
 import (
 	"testing"
 
-	"github.com/AlecAivazis/survey/core"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/AlecAivazis/survey.v1/core"
 )
 
 func init() {

--- a/select.go
+++ b/select.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/AlecAivazis/survey/core"
-	"github.com/AlecAivazis/survey/terminal"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 /*

--- a/select_test.go
+++ b/select_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/AlecAivazis/survey/core"
-	"github.com/AlecAivazis/survey/terminal"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
 
 func init() {

--- a/survey.go
+++ b/survey.go
@@ -3,7 +3,7 @@ package survey
 import (
 	"errors"
 
-	"github.com/AlecAivazis/survey/core"
+	"gopkg.in/AlecAivazis/survey.v1/core"
 )
 
 // PageSize is the default maximum number of items to show in select/multiselect prompts

--- a/survey_test.go
+++ b/survey_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/AlecAivazis/survey/core"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/AlecAivazis/survey.v1/core"
 )
 
 func init() {

--- a/tests/ask.go
+++ b/tests/ask.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/AlecAivazis/survey"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 // the questions to ask

--- a/tests/confirm.go
+++ b/tests/confirm.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/AlecAivazis/survey"
-	"github.com/AlecAivazis/survey/tests/util"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1/tests/util"
 )
 
 var answer = false

--- a/tests/doubleSelect.go
+++ b/tests/doubleSelect.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/AlecAivazis/survey"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 var simpleQs = []*survey.Question{

--- a/tests/help.go
+++ b/tests/help.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/AlecAivazis/survey"
-	"github.com/AlecAivazis/survey/tests/util"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1/tests/util"
 )
 
 var (

--- a/tests/input.go
+++ b/tests/input.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/AlecAivazis/survey"
-	"github.com/AlecAivazis/survey/tests/util"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1/tests/util"
 )
 
 var val = ""

--- a/tests/longSelect.go
+++ b/tests/longSelect.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/AlecAivazis/survey"
+import "gopkg.in/AlecAivazis/survey.v1"
 
 func main() {
 	color := ""

--- a/tests/multiselect.go
+++ b/tests/multiselect.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/AlecAivazis/survey"
-	"github.com/AlecAivazis/survey/tests/util"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1/tests/util"
 )
 
 var answer = []string{}

--- a/tests/password.go
+++ b/tests/password.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/AlecAivazis/survey"
-	"github.com/AlecAivazis/survey/tests/util"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1/tests/util"
 )
 
 var value = ""

--- a/tests/select.go
+++ b/tests/select.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/AlecAivazis/survey"
-	"github.com/AlecAivazis/survey/tests/util"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1/tests/util"
 )
 
 var answer = ""

--- a/tests/selectThenInput.go
+++ b/tests/selectThenInput.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/AlecAivazis/survey"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 // the questions to ask

--- a/tests/util/test.go
+++ b/tests/util/test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/AlecAivazis/survey"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 type TestTableEntry struct {


### PR DESCRIPTION
This PR fixes a bug reported in #89 where internal imports were still using `github.com/alecaivazis/survey` which made changing things in `survey/core` feel clunky since they had to be changed in `alecaivazis/survey`.