### PR TITLE
Feat/nested result casts

### DIFF
--- a/core/write.go
+++ b/core/write.go
@@ -221,14 +221,15 @@ func copy(t reflect.Value, v reflect.Value) (err error) {
 			// if its a slice
 			case reflect.Slice:
 				// an object of the correct type
-				obj := reflect.Zero(t.Type().Elem())
-				fmt.Println("from", v.Index(i), v.Index(i).Type().Kind(), "to", obj, obj.Kind())
-				// write the appropriate value to the obj
-				copy(obj, v.Index(i))
-				fmt.Println(">>", obj)
+				obj := reflect.Indirect(reflect.New(t.Type().Elem()))
+
+				// write the appropriate value to the obj and catch any errors
+				if err := copy(obj, v.Index(i)); err != nil {
+					return err
+				}
 
 				// just append the value to the end
-				reflect.Append(t, obj)
+				t.Set(reflect.Append(t, obj))
 			// otherwise it could be an array
 			case reflect.Array:
 				// set the index to the appropriate value

--- a/core/write.go
+++ b/core/write.go
@@ -109,6 +109,16 @@ func findFieldIndex(s reflect.Value, name string) (int, error) {
 	return -1, fmt.Errorf("could not find field matching %v", name)
 }
 
+// isList returns true if the element is something we can Len()
+func isList(v reflect.Value) bool {
+	switch v.Type().Kind() {
+	case reflect.Array, reflect.Slice:
+		return true
+	default:
+		return false
+	}
+}
+
 // Write takes a value and copies it to the target
 func copy(t reflect.Value, v reflect.Value) (err error) {
 	// if something ends up panicing we need to catch it in a deferred func
@@ -125,7 +135,7 @@ func copy(t reflect.Value, v reflect.Value) (err error) {
 		}
 	}()
 
-	// attempt to copy the underlying value to the target
+	// if we are copying from a string result to something else
 	if v.Kind() == reflect.String && v.Type() != t.Type() {
 		var castVal interface{}
 		var casterr error
@@ -202,7 +212,33 @@ func copy(t reflect.Value, v reflect.Value) (err error) {
 		return
 	}
 
-	t.Set(v)
+	// if we are copying from one slice or array to another
+	if isList(v) && isList(t) {
+		// loop over every item in the desired value
+		for i := 0; i < v.Len(); i++ {
+			// write to the target given its kind
+			switch t.Kind() {
+			// if its a slice
+			case reflect.Slice:
+				// an object of the correct type
+				obj := reflect.Zero(t.Type().Elem())
+				fmt.Println("from", v.Index(i), v.Index(i).Type().Kind(), "to", obj, obj.Kind())
+				// write the appropriate value to the obj
+				copy(obj, v.Index(i))
+				fmt.Println(">>", obj)
+
+				// just append the value to the end
+				reflect.Append(t, obj)
+			// otherwise it could be an array
+			case reflect.Array:
+				// set the index to the appropriate value
+				copy(t.Slice(i, i+1).Index(0), v.Index(i))
+			}
+		}
+	} else {
+		// set the value to the target
+		t.Set(v)
+	}
 
 	// we're done
 	return

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -151,7 +151,7 @@ func TestWrite_writesStringSliceToIntSlice(t *testing.T) {
 }
 
 func TestWrite_writesStringArrayToIntArray(t *testing.T) {
-	// make a slice of int to write to
+	// make an array of int to write to
 	target := [3]int{}
 
 	// write the answer

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -154,6 +154,32 @@ func TestWrite_returnsErrorIfInvalidMapType(t *testing.T) {
 	}
 }
 
+func TestWrite_writesStringSliceToIntSlice(t *testing.T) {
+	// make a slice of int to write to
+	target := []int{}
+
+	// write the answer
+	err := WriteAnswer(&target, "name", []string{"1", "2", "3"})
+
+	// make sure there was no error
+	assert.Nil(t, err, "WriteSlice to Int Slice")
+	// and we got what we wanted
+	assert.Equal(t, []int{1, 2, 3}, target)
+}
+
+func TestWrite_writesStringArrayToIntArray(t *testing.T) {
+	// make a slice of int to write to
+	target := [3]int{}
+
+	// write the answer
+	err := WriteAnswer(&target, "name", [3]string{"1", "2", "3"})
+
+	// make sure there was no error
+	assert.Nil(t, err, "WriteArray to Int Array")
+	// and we got what we wanted
+	assert.Equal(t, [3]int{1, 2, 3}, target)
+}
+
 func TestWriteAnswer_returnsErrWhenFieldNotFound(t *testing.T) {
 	// the struct to hold the answer
 	ptr := struct{ Name string }{}

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -55,24 +55,7 @@ func TestWrite_canWriteSlice(t *testing.T) {
 	WriteAnswer(&ptr, "", []string{"hello", "world"})
 
 	// make sure there are two entries
-	if len(ptr) != 2 {
-		// the test failed
-		t.Errorf("Incorrect number of entries in written list. Expected 2, found %v.", len(ptr))
-		// dont move on
-		return
-	}
-
-	// make sure the first entry is hello
-	if ptr[0] != "hello" {
-		// the test failed
-		t.Errorf("incorrect first value in written pointer. expected hello found %v.", ptr[0])
-	}
-
-	// make sure the second entry is world
-	if ptr[1] != "world" {
-		// the test failed
-		t.Errorf("incorrect second value in written pointer. expected world found %v.", ptr[0])
-	}
+	assert.Equal(t, []string{"hello", "world"}, ptr)
 }
 
 func TestWrite_recoversInvalidReflection(t *testing.T) {

--- a/input.go
+++ b/input.go
@@ -15,7 +15,6 @@ and accepts the input with the enter key. Response type is a string.
 	prompt := &survey.Input{ Message: "What is your name?" }
 	survey.AskOne(prompt, &name, nil)
 */
-
 type Input struct {
 	core.Renderer
 	Message string

--- a/tests/editor.go
+++ b/tests/editor.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/AlecAivazis/survey"
+	"github.com/AlecAivazis/survey/tests/util"
+)
+
+var answer = ""
+
+var goodTable = []TestUtil.TestTableEntry{
+	{
+		"should open in editor", &survey.Editor{
+			Message: "should open",
+		}, &answer,
+	},
+	{
+		"has help", &survey.Editor{
+			Message: "press ? to see message",
+			Help:    "Does this work?",
+		}, &answer,
+	},
+}
+
+func main() {
+	TestUtil.RunTable(goodTable)
+}


### PR DESCRIPTION
This PR extends the type handling support of `survey` to handle nested casts - for example the following is now supported:

```golang
// the questions to ask
var qs = []*survey.Question{
    {
        Name: "choices",
        Prompt:   &survey.MultiSelect{
            Message: "How old are you?",
            Options: []string{"1", "2", "3"},
        },
    },
}

func main() {
    // the answers will be written to this struct
    answers := struct {
        Choices           []int                     
    }{}

    // perform the questions
    _ := survey.Ask(qs, &answers)

    // answers.Choices should contain integer casted versions of the selected choices
}
```