### PR TITLE
changed default prompt icons to be more compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Jetbrains
+.idea
+*.iml

--- a/confirm_test.go
+++ b/confirm_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/AlecAivazis/survey.v1/core"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
+	"fmt"
 )
 
 func init() {
@@ -26,32 +27,32 @@ func TestConfirmRender(t *testing.T) {
 			"Test Confirm question output with default true",
 			Confirm{Message: "Is pizza your favorite food?", Default: true},
 			ConfirmTemplateData{},
-			`? Is pizza your favorite food? (Y/n) `,
+			fmt.Sprintf("%s Is pizza your favorite food? (Y/n) ", core.QuestionIcon),
 		},
 		{
 			"Test Confirm question output with default false",
 			Confirm{Message: "Is pizza your favorite food?", Default: false},
 			ConfirmTemplateData{},
-			`? Is pizza your favorite food? (y/N) `,
+			fmt.Sprintf("%s Is pizza your favorite food? (y/N) ", core.QuestionIcon),
 		},
 		{
 			"Test Confirm answer output",
 			Confirm{Message: "Is pizza your favorite food?"},
 			ConfirmTemplateData{Answer: "Yes"},
-			"? Is pizza your favorite food? Yes\n",
+			fmt.Sprintf("%s Is pizza your favorite food? Yes\n", core.QuestionIcon),
 		},
 		{
 			"Test Confirm with help but help message is hidden",
 			Confirm{Message: "Is pizza your favorite food?", Help: "This is helpful"},
 			ConfirmTemplateData{},
-			"? Is pizza your favorite food? [? for help] (y/N) ",
+			fmt.Sprintf("%s Is pizza your favorite food? [%s for help] (y/N) ", core.QuestionIcon, core.HelpInputRune),
 		},
 		{
 			"Test Confirm help output with help message shown",
 			Confirm{Message: "Is pizza your favorite food?", Help: "This is helpful"},
 			ConfirmTemplateData{ShowHelp: true},
-			`ⓘ This is helpful
-? Is pizza your favorite food? (y/N) `,
+			fmt.Sprintf(`%s This is helpful
+%s Is pizza your favorite food? (y/N) `, core.HelpIcon, core.QuestionIcon),
 		},
 	}
 

--- a/confirm_test.go
+++ b/confirm_test.go
@@ -45,7 +45,7 @@ func TestConfirmRender(t *testing.T) {
 			"Test Confirm with help but help message is hidden",
 			Confirm{Message: "Is pizza your favorite food?", Help: "This is helpful"},
 			ConfirmTemplateData{},
-			fmt.Sprintf("%s Is pizza your favorite food? [%s for help] (y/N) ", core.QuestionIcon, core.HelpInputRune),
+			fmt.Sprintf("%s Is pizza your favorite food? [%s for help] (y/N) ", core.QuestionIcon, string(core.HelpInputRune)),
 		},
 		{
 			"Test Confirm help output with help message shown",

--- a/core/template.go
+++ b/core/template.go
@@ -12,14 +12,14 @@ var DisableColor = false
 var (
 	HelpInputRune = '?'
 
-	ErrorIcon    = "✘"
-	HelpIcon     = "ⓘ"
+	ErrorIcon    = "X"
+	HelpIcon     = "????"
 	QuestionIcon = "?"
 
-	MarkedOptionIcon   = "◉"
-	UnmarkedOptionIcon = "◯"
+	MarkedOptionIcon   = "[x]"
+	UnmarkedOptionIcon = "[ ]"
 
-	SelectFocusIcon = "❯"
+	SelectFocusIcon = ">"
 )
 
 var TemplateFuncs = map[string]interface{}{

--- a/core/template.go
+++ b/core/template.go
@@ -10,17 +10,44 @@ import (
 var DisableColor = false
 
 var (
+	// HelpInputRune is the rune which the user should enter to trigger 
+	// more detailed question help
 	HelpInputRune = '?'
 
+	// ErrorIcon is the text will be be shown before an error
 	ErrorIcon    = "X"
+
+	// HelpIcon is the text which will be shown before more detailed question 
+	// help
 	HelpIcon     = "????"
+	// QuestionIcon is the text which will be shown before a question Message
 	QuestionIcon = "?"
 
+	// MarkedOptionIcon is the text that will be prepended before a 
+	// selected multiselect option
 	MarkedOptionIcon   = "[x]"
+	// UnmarkedOptionIcon is the text that will be prepended before a
+	// unselected multiselect option
 	UnmarkedOptionIcon = "[ ]"
 
+	// SelectFocusIcon holds the text prepended to an option to signify the 
+	// user is currently focusing that option
 	SelectFocusIcon = ">"
 )
+
+// SetFancyIcons changes the err, help, marked, and focus input icons to their fancier forms. These forms may not
+// be compatible with most terminals. This function will not touch the QuestionIcon as its fancy and non fancy form are
+// the same
+func SetFancyIcons() {
+	ErrorIcon = "✘"
+	HelpIcon = "ⓘ"
+	// QuestionIcon fancy and non-fancy form are the same
+
+	MarkedOptionIcon = "◉"
+	UnmarkedOptionIcon = "◯"
+
+	SelectFocusIcon = "❯"
+}
 
 var TemplateFuncs = map[string]interface{}{
 	// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format


### PR DESCRIPTION
This PR changes the default prompt icons in core to those discussed in #93.  

This should make survey more compatible with a layman's terminal which may not have a patched font to display the previous fancier prompt icons.  

Additionally I added a `SetFancyIcons()` method for those who wish to still use the previous icons.