### PR TITLE
Term: Fix intensity attr on Windows

### DIFF
--- a/terminal/output_windows.go
+++ b/terminal/output_windows.go
@@ -197,6 +197,30 @@ func (w *Writer) applySelectGraphicRendition(arg string) {
 			if (n-40)&4 != 0 {
 				attr |= backgroundBlue
 			}
+		case 90 <= n && n <= 97:
+			attr = (attr & backgroundMask)
+			attr |= foregroundIntensity
+			if (n-90)&1 != 0 {
+				attr |= foregroundRed
+			}
+			if (n-90)&2 != 0 {
+				attr |= foregroundGreen
+			}
+			if (n-90)&4 != 0 {
+				attr |= foregroundBlue
+			}
+		case 100 <= n && n <= 107:
+			attr = (attr & foregroundMask)
+			attr |= backgroundIntensity
+			if (n-100)&1 != 0 {
+				attr |= backgroundRed
+			}
+			if (n-100)&2 != 0 {
+				attr |= backgroundGreen
+			}
+			if (n-100)&4 != 0 {
+				attr |= backgroundBlue
+			}
 		}
 	}
 


### PR DESCRIPTION
https://github.com/AlecAivazis/survey/blob/ced9eac915e96d8c1f2233d4bfc21c51db497b4d/select.go#L46
`green+hb` is actually `\x1b[1;92m`, but `terminal/output_windows.go` did not handle the range.

Before:
![image](https://user-images.githubusercontent.com/17795845/31321407-4849b2ea-acb8-11e7-8e8f-dbd30ebfb6cd.png)

After:
![image](https://user-images.githubusercontent.com/17795845/31321414-69786394-acb8-11e7-95b3-5c140da40a32.png)
