### PR TITLE
Add support for other in select and multi select

### DIFF
--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -21,6 +21,12 @@ func TestMultiSelectRender(t *testing.T) {
 		Options: []string{"foo", "bar", "baz", "buz"},
 		Default: []string{"bar", "buz"},
 	}
+	promptWithOther := MultiSelect{
+		Message: "Pick your words:",
+		Options: []string{"foo", "bar", "baz", "buz"},
+		Default: []string{"bar", "buz"},
+		Other:   true,
+	}
 
 	helpfulPrompt := prompt
 	helpfulPrompt.Help = "This is helpful"
@@ -85,6 +91,22 @@ func TestMultiSelectRender(t *testing.T) {
   ◉  bar
 ❯ ◯  baz
   ◉  buz
+`,
+		},
+		{
+			"Test MultiSelect question output with other",
+			promptWithOther,
+			MultiSelectTemplateData{
+				SelectedIndex: 2,
+				PageEntries:   append(prompt.Options, "Other"),
+				Checked:       map[string]bool{"bar": true, "buz": true},
+			},
+			`? Pick your words:
+  ◯  foo
+  ◉  bar
+❯ ◯  baz
+  ◉  buz
+  ◯  Other
 `,
 		},
 	}

--- a/select_test.go
+++ b/select_test.go
@@ -21,6 +21,12 @@ func TestSelectRender(t *testing.T) {
 		Options: []string{"foo", "bar", "baz", "buz"},
 		Default: "baz",
 	}
+	promptWithOther := Select{
+		Message: "Pick your word:",
+		Options: []string{"foo", "bar", "baz", "buz"},
+		Default: "baz",
+		Other:   true,
+	}
 
 	helpfulPrompt := prompt
 	helpfulPrompt.Help = "This is helpful"
@@ -69,6 +75,18 @@ func TestSelectRender(t *testing.T) {
   bar
 ❯ baz
   buz
+`,
+		},
+		{
+			"Test Select question output with other",
+			promptWithOther,
+			SelectTemplateData{SelectedIndex: 2, PageEntries: append(prompt.Options, "Other")},
+			`? Pick your word:
+  foo
+  bar
+❯ baz
+  buz
+  Other
 `,
 		},
 	}


### PR DESCRIPTION
Add Other member to Select and MultiSelect structs.
If set to true another choice will appear, after all supplied options,
named Other, if selected the user is prompted to supply their input.
Used to have a set of choices but allowing the user to enter their own
value for the prompt.

This commit only includes tests for the output, not for any interaction.

This PR includes a proof of concept for the feature for discussion. For being a complete PR tests needs to be added for the functionality.

* Is this a feature you would like to have in the library?
* I'm not super happy about how the output looks, do you have any suggestions on how to improve it?
* Any other comments?

## Output example

This is one select and one multi select with choices of colors, with other choice added.

```
$ go run main.go
? Choose a color:
  red
❯ blue
  green
  Other

$ go run main.go
? Choose a color: blue
? Choose any color:
  ◉  red
  ◯  blue
  ◉  green
❯ ◉  Other

$ go run main.go
? Choose a color: blue
? Choose any color:
  ◉  red
  ◯  blue
  ◉  green
❯ ◉  Other
? Other pink

$ go run main.go
? Choose a color: blue
? Choose any color:
? Choose any color: red, green, pink
```