### PR TITLE
allow to change the editor behavior

### DIFF
--- a/editor_test.go
+++ b/editor_test.go
@@ -34,6 +34,12 @@ func TestEditorRender(t *testing.T) {
 			"? What is your favorite month: (April) [Enter to launch editor] ",
 		},
 		{
+			"Test Editor question output with HideDefault",
+			Editor{Message: "What is your favorite month:", Default: "April", HideDefault: true},
+			EditorTemplateData{},
+			"? What is your favorite month: [Enter to launch editor] ",
+		},
+		{
 			"Test Editor answer output",
 			Editor{Message: "What is your favorite month:"},
 			EditorTemplateData{Answer: "October", ShowAnswer: true},

--- a/tests/editor.go
+++ b/tests/editor.go
@@ -19,6 +19,20 @@ var goodTable = []TestUtil.TestTableEntry{
 			Help:    "Does this work?",
 		}, &answer,
 	},
+	{
+		"should not include the default value in the prompt", &survey.Editor{
+			Message:     "the default value 'Hello World' should not include in the prompt",
+			HideDefault: true,
+			Default:     "Hello World",
+		}, &answer,
+	},
+	{
+		"should write the default value to the temporary file before the launch of the editor", &survey.Editor{
+			Message:       "the default value 'Hello World' is written to the temporary file before the launch of the editor",
+			AppendDefault: true,
+			Default:       "Hello World",
+		}, &answer,
+	},
 }
 
 func main() {


### PR DESCRIPTION
Add two fields `HideDefault` and `AppendDefaul` to `Editor`.

If `HideDefault` is `true`, the default value is not shown
before the launch of the editor. By default this value is `false`.

If `AppendDefault` is `true`, the default value is written to the temporary
file before the launch of the editor and `Prompt()` returns the empty
string if the contents of the temporary file is empty.
By default this value is `false`.