### PR TITLE
Terminal license

### DIFF
--- a/terminal/README.md
+++ b/terminal/README.md
@@ -1,0 +1,3 @@
+# survey/terminal
+
+This package started as a copy of [kokuban/go-ansi](http://github.com/k0kubun/go-ansi) but has since been modified to fit survey's specific needs.


### PR DESCRIPTION
This PR addresses #112  adds the license information for the terminal package which began as a slight modification of `go-ansi`.