### PR TITLE
boolean values pass through the required validator

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -8,8 +8,11 @@ import (
 
 // Required does not allow an empty value
 func Required(val interface{}) error {
+	// the reflect value of the result
+	value := reflect.ValueOf(val)
+
 	// if the value passed in is the zero value of the appropriate type
-	if isZero(reflect.ValueOf(val)) {
+	if isZero(value) && value.Kind() != reflect.Bool {
 		return errors.New("Value is required")
 	}
 	return nil

--- a/validate_test.go
+++ b/validate_test.go
@@ -35,6 +35,17 @@ func TestRequired_canSucceedOnMap(t *testing.T) {
 	}
 }
 
+func TestRequired_passesOnFalse(t *testing.T) {
+	// a false value to pass to the validator
+	val := false
+
+	// if the boolean is invalid
+	if notValid := Required(val); notValid != nil {
+		//
+		t.Error("False failed a required check.")
+	}
+}
+
 func TestRequired_canFailOnMap(t *testing.T) {
 	// an non-empty map to test
 	val := map[string]int{}


### PR DESCRIPTION
This PR fixes #120 by adding booleans as a special case in the `Required` validator. The logic behind this changed is describe in that issue, copied below
>  It's definitely an unexpected consequence of the zero value for a boolean being false. I think it would make sense to check if the type we are validating against is a boolean, and having it pass through survey.Required without causing an error. While this is slightly off of the documented behavior (since false is the zero value), I think it makes sense from the mindset that the prompt type might change but you requiring a response does not, and survey.Required should check that any answer was given, not just one of the zero value.