### PR TITLE
added more instructions to the help prompt for select and multi select

### DIFF
--- a/multiselect.go
+++ b/multiselect.go
@@ -52,7 +52,7 @@ var MultiSelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
-  {{- if and .Help (not .ShowHelp)}} {{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}}{{end}}
+	{{- "  "}}{{- color "cyan"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $option := .PageEntries}}
     {{- if eq $ix $.SelectedIndex}}{{color "cyan"}}{{ SelectFocusIcon }}{{color "reset"}}{{else}} {{end}}
@@ -105,7 +105,7 @@ func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, 
 		m.filter = ""
 	} else if key == terminal.KeyDelete || key == terminal.KeyBackspace {
 		if m.filter != "" {
-			m.filter = m.filter[0:len(m.filter)-1]
+			m.filter = m.filter[0 : len(m.filter)-1]
 		}
 	} else if key >= terminal.KeySpace {
 		m.filter += string(key)
@@ -158,8 +158,6 @@ func (m *MultiSelect) filterOptions() []string {
 	}
 	return answer
 }
-
-
 
 func (m *MultiSelect) Prompt() (interface{}, error) {
 	// compute the default state

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -39,7 +39,7 @@ func TestMultiSelectRender(t *testing.T) {
 				PageEntries:   prompt.Options,
 				Checked:       map[string]bool{"bar": true, "buz": true},
 			},
-			`? Pick your words:
+			`? Pick your words:  [Use arrows to move, type to filter]
   ◯  foo
   ◉  bar
 ❯ ◯  baz
@@ -63,7 +63,7 @@ func TestMultiSelectRender(t *testing.T) {
 				PageEntries:   prompt.Options,
 				Checked:       map[string]bool{"bar": true, "buz": true},
 			},
-			`? Pick your words: [? for help]
+			`? Pick your words:  [Use arrows to move, type to filter, ? for more help]
   ◯  foo
   ◉  bar
 ❯ ◯  baz
@@ -80,7 +80,7 @@ func TestMultiSelectRender(t *testing.T) {
 				ShowHelp:      true,
 			},
 			`ⓘ This is helpful
-? Pick your words:
+? Pick your words:  [Use arrows to move, type to filter]
   ◯  foo
   ◉  bar
 ❯ ◯  baz

--- a/select.go
+++ b/select.go
@@ -51,7 +51,7 @@ var SelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else}}
-  {{- if and .Help (not .ShowHelp)}} {{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}}{{end}}
+  {{- "  "}}{{- color "cyan"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $choice := .PageEntries}}
     {{- if eq $ix $.SelectedIndex}}{{color "cyan+b"}}{{ SelectFocusIcon }} {{else}}{{color "default+hb"}}  {{end}}
@@ -102,7 +102,7 @@ func (s *Select) OnChange(line []rune, pos int, key rune) (newLine []rune, newPo
 		s.filter = ""
 	} else if key == terminal.KeyDelete || key == terminal.KeyBackspace {
 		if s.filter != "" {
-			s.filter = s.filter[0:len(s.filter)-1]
+			s.filter = s.filter[0 : len(s.filter)-1]
 		}
 	} else if key >= terminal.KeySpace {
 		s.filter += string(key)

--- a/select_test.go
+++ b/select_test.go
@@ -35,7 +35,7 @@ func TestSelectRender(t *testing.T) {
 			"Test Select question output",
 			prompt,
 			SelectTemplateData{SelectedIndex: 2, PageEntries: prompt.Options},
-			`? Pick your word:
+			`? Pick your word:  [Use arrows to move, type to filter]
   foo
   bar
 ❯ baz
@@ -52,7 +52,7 @@ func TestSelectRender(t *testing.T) {
 			"Test Select question output with help hidden",
 			helpfulPrompt,
 			SelectTemplateData{SelectedIndex: 2, PageEntries: prompt.Options},
-			`? Pick your word: [? for help]
+			`? Pick your word:  [Use arrows to move, type to filter, ? for more help]
   foo
   bar
 ❯ baz
@@ -64,7 +64,7 @@ func TestSelectRender(t *testing.T) {
 			helpfulPrompt,
 			SelectTemplateData{SelectedIndex: 2, ShowHelp: true, PageEntries: prompt.Options},
 			`ⓘ This is helpful
-? Pick your word:
+? Pick your word:  [Use arrows to move, type to filter]
   foo
   bar
 ❯ baz


### PR DESCRIPTION
This PR adds some more instructions to the select and multi select prompt in order to tell the user that they can filter the options. This does not fully account for the docs @jstrachan brought up in #127 but it's at least something so people won't be confused if they start typing and see options disappearing.
