### PR TITLE
Fixed special keys and terminal overflow

### DIFF
--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -61,16 +61,16 @@ func CursorHide() {
 func CursorMove(x int, y int) {
 	fmt.Printf("\x1b[%d;%df", x, y)
 }
+
 // CursorSave saves the current position
 func CursorSave() {
 	fmt.Print("\x1b7")
 }
 
-// CursorSave restores the current position of the cursor
+// CursorRestore restores the saved position of the cursor
 func CursorRestore() {
 	fmt.Print("\x1b8")
 }
-
 
 // CursorLocation returns the current location of the cursor in the terminal
 func CursorLocation() (*Coord, error) {
@@ -114,11 +114,11 @@ func CursorLocation() (*Coord, error) {
 	return nil, fmt.Errorf("could not compute the cursor position using ascii escape sequences")
 }
 
-func (cur Coord) CursorIsAtLineEnd(size *Coord) bool{
+func (cur Coord) CursorIsAtLineEnd(size *Coord) bool {
 	return cur.X == size.X
 }
 
-func (cur Coord) CursorIsAtLineBegin() bool{
+func (cur Coord) CursorIsAtLineBegin() bool {
 	return cur.X == COORDINATE_SYSTEM_BEGIN
 }
 
@@ -128,13 +128,10 @@ func Size() (*Coord, error) {
 	// of the terminal, ask for the current location and then move the
 	// cursor back where we started
 
-	// hide the cursor
+	// hide the cursor (so it doesn't blink when getting the size of the terminal)
 	CursorHide()
 	// save the current location of the cursor
-	origin, err := CursorLocation()
-	if err != nil {
-		return nil, err
-	}
+	CursorSave()
 
 	// move the cursor to the very bottom of the terminal
 	CursorMove(999, 999)
@@ -146,8 +143,7 @@ func Size() (*Coord, error) {
 	}
 
 	// move back where we began
-	CursorUp(int(bottom.Y - origin.Y))
-	CursorHorizontalAbsolute(int(origin.X))
+	CursorRestore()
 
 	// show the cursor
 	CursorShow()

--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -60,6 +60,16 @@ func CursorHide() {
 func CursorMove(x int, y int) {
 	fmt.Printf("\x1b[%d;%df", x, y)
 }
+// CursorSave saves the current position
+func CursorSave() {
+	fmt.Print("\x1b7")
+}
+
+// CursorSave restores the current position of the cursor
+func CursorRestore() {
+	fmt.Print("\x1b8")
+}
+
 
 // CursorLocation returns the current location of the cursor in the terminal
 func CursorLocation() (*Coord, error) {
@@ -101,6 +111,14 @@ func CursorLocation() (*Coord, error) {
 
 	// it didn't work so return an error
 	return nil, fmt.Errorf("could not compute the cursor position using ascii escape sequences")
+}
+
+func (cur Coord) CursorIsAtLineEnd(size *Coord) bool{
+	return cur.X == size.X
+}
+
+func (cur Coord) CursorIsAtLineBegin() bool{
+	return cur.X == 1
 }
 
 // Size returns the height and width of the terminal.

--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -119,7 +119,7 @@ func (cur Coord) CursorIsAtLineEnd(size *Coord) bool{
 }
 
 func (cur Coord) CursorIsAtLineBegin() bool{
-	return cur.X == 1
+	return cur.X == COORDINATE_SYSTEM_BEGIN
 }
 
 // Size returns the height and width of the terminal.

--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 )
 
+var COORDINATE_SYSTEM_BEGIN Short = 1
 // CursorUp moves the cursor n cells to up.
 func CursorUp(n int) {
 	fmt.Printf("\x1b[%dA", n)

--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -127,6 +127,8 @@ func Size() (*Coord, error) {
 	// of the terminal, ask for the current location and then move the
 	// cursor back where we started
 
+	// hide the cursor
+	CursorHide()
 	// save the current location of the cursor
 	origin, err := CursorLocation()
 	if err != nil {
@@ -146,6 +148,8 @@ func Size() (*Coord, error) {
 	CursorUp(int(bottom.Y - origin.Y))
 	CursorHorizontalAbsolute(int(origin.X))
 
+	// show the cursor
+	CursorShow()
 	// sice the bottom was calcuated in the lower right corner, it
 	// is the dimensions we are looking for
 	return bottom, nil

--- a/terminal/cursor_windows.go
+++ b/terminal/cursor_windows.go
@@ -5,7 +5,9 @@ import (
 	"syscall"
 	"unsafe"
 )
-
+var COORDINATE_SYSTEM_BEGIN Short = 0
+// shared variable to save the cursor location from CursorSave()
+var cursorLoc Coord
 func CursorUp(n int) {
 	cursorMove(0, n)
 }
@@ -20,6 +22,25 @@ func CursorForward(n int) {
 
 func CursorBack(n int) {
 	cursorMove(-1*n, 0)
+}
+
+// save the cursor location
+func CursorSave() {
+	cursorLoc, _ = CursorLocation()
+}
+
+func CursorRestore() {
+	handle := syscall.Handle(os.Stdout.Fd())
+	// restore it to the original position
+	procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursorLoc))))
+}
+
+func (cur Coord) CursorIsAtLineEnd(size *Coord) bool{
+	return cur.X == size.X
+}
+
+func (cur Coord) CursorIsAtLineBegin() bool{
+	return cur.X == 0
 }
 
 func cursorMove(x int, y int) {
@@ -91,11 +112,13 @@ func CursorLocation() (Coord, error) {
 	return csbi.cursorPosition, nil
 }
 
-func Size() (Coord, error) {
+func Size() (*Coord, error) {
 	handle := syscall.Handle(os.Stdout.Fd())
 
 	var csbi consoleScreenBufferInfo
 	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
-
-	return csbi.size, nil
+	// windows' coordinate system begins at (0, 0)
+	csbi.size.X--
+	csbi.size.Y--
+	return &csbi.size, nil
 }

--- a/terminal/cursor_windows.go
+++ b/terminal/cursor_windows.go
@@ -5,9 +5,11 @@ import (
 	"syscall"
 	"unsafe"
 )
+
 var COORDINATE_SYSTEM_BEGIN Short = 0
 // shared variable to save the cursor location from CursorSave()
 var cursorLoc Coord
+
 func CursorUp(n int) {
 	cursorMove(0, n)
 }
@@ -35,11 +37,11 @@ func CursorRestore() {
 	procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursorLoc))))
 }
 
-func (cur Coord) CursorIsAtLineEnd(size *Coord) bool{
+func (cur Coord) CursorIsAtLineEnd(size *Coord) bool {
 	return cur.X == size.X
 }
 
-func (cur Coord) CursorIsAtLineBegin() bool{
+func (cur Coord) CursorIsAtLineBegin() bool {
 	return cur.X == 0
 }
 

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -42,7 +42,6 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			// we're done processing the input
 			return line, nil
 		}
-
 		// if the user interrupts (ie with ctrl+c)
 		if r == KeyInterrupt {
 			// go to the beginning of the next line
@@ -90,8 +89,8 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 						Printf("%c", char)
 
 					}
-					// erase what's left from last print
-					Printf("\x1bE")
+					// erase what's left over from last print
+					CursorNextLine(1)
 					EraseLine(ERASE_LINE_END)
 
 					// restore cursor
@@ -121,7 +120,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			if index > 0 {
 				//move the cursor to the prev line if necessary
 				if cursorCurrent.CursorIsAtLineBegin() {
-					CursorUp(1)
+					CursorPreviousLine(1)
 					CursorForward(int(terminalSize.X))
 				} else {
 					CursorBack(1)
@@ -181,7 +180,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			for index != len(line) {
 				if cursorCurrent.CursorIsAtLineEnd(terminalSize){
 					CursorNextLine(1)
-					cursorCurrent.X = 1
+					cursorCurrent.X = COORDINATE_SYSTEM_BEGIN
 					cursorCurrent.Y++
 
 				} else {
@@ -204,7 +203,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					Printf("%c", char)
 				}
 				// erase what's left on last line
-				Printf("\x1bE")
+				CursorNextLine(1)
 				EraseLine(ERASE_LINE_END)
 
 				// restore cursor
@@ -251,13 +250,13 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			for _, char := range line[index:] {
 				EraseLine(ERASE_LINE_END)
 				if mask == 0{
-				Printf("%c", char)
+					Printf("%c", char)
 				} else {
 					Printf("%c", mask)
 				}
 			}
 			// erase what's left on last line
-			Printf("\x1bE")
+			CursorNextLine(1)
 			EraseLine(ERASE_LINE_END)
 
 			// restore cursor

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -37,7 +37,6 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 		cursorCurrent, err := CursorLocation()
 		// if the user pressed enter or some other newline/termination like ctrl+d
 		if r == '\r' || r == '\n' || r == KeyEndTransmission {
-			// go to the beginning of the next line
 
 			// delete what's printed out on the console screen (cleanup)
 			for index > 0 {
@@ -54,10 +53,8 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 				}
 				index--
 			}
-
-
-			Print("\r")
-
+			// move the cursor the a new line
+			CursorNextLine(1)
 			// we're done processing the input
 			return line, nil
 		}
@@ -275,18 +272,20 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 				}
 				cursorCurrent.X++
 			}
-			// erase what's left on last line
+			// if we are at the last line, we want to visually insert a new line and append to it.
 			if cursorCurrent.CursorIsAtLineEnd(terminalSize) && cursorCurrent.Y == terminalSize.Y {
+				// add a new line to the terminal
 				Println()
+				// restore the position of the cursor horizontally
 				CursorRestore()
-				CursorUp(int(terminalSize.Y - cursorCurrent.Y))
-				continue
+				// restore the position of the cursor vertically
+				CursorUp(1)
 			} else {
 			// restore cursor
 			CursorRestore()
 			}
+			// check if cursor needs to move to next line
 			cursorCurrent, _ = CursorLocation()
-
 			if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
 				CursorNextLine(1)
 			} else {

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -176,6 +176,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 				index--
 			}
 			continue
+		// user pressed end
 		} else if r == SpecialKeyEnd {
 			for index != len(line) {
 				if cursorCurrent.CursorIsAtLineEnd(terminalSize){
@@ -190,6 +191,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 				index++
 			}
 			continue
+		// user pressed forward delete key
 		} else if r == SpecialKeyDelete {
 			// if index at the end of the line nothing to delete
 			if index != len(line){
@@ -242,39 +244,34 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			// save the current position of the cursor
 			CursorSave()
 
-			// visually insert the character by deleting the rest of the line
 			EraseLine(ERASE_LINE_END)
-			// print the rest of the word after
+
+			// remove the symbol after the cursor
+			// print the updated line
 			for _, char := range line[index:] {
-				// print characters to the new line appropriately
-				if  cursorCurrent.X == terminalSize.X {
-					CursorNextLine(1)
-					EraseLine(ERASE_LINE_END)
-					cursorCurrent.Y++
-					cursorCurrent.X = 1
-				}
-				// if we don't need to mask the input
-				if mask == 0 {
-					// just print the character the user pressed
-					Printf("%c", char)
+				EraseLine(ERASE_LINE_END)
+				if mask == 0{
+				Printf("%c", char)
 				} else {
-					// otherwise print the mask we were given
 					Printf("%c", mask)
 				}
-				cursorCurrent.X++
 			}
-			// leave the cursor where the user left it
+			// erase what's left on last line
+			Printf("\x1bE")
+			EraseLine(ERASE_LINE_END)
+
+			// restore cursor
 			CursorRestore()
 			cursorCurrent, _ = CursorLocation()
-			if cursorCurrent.X == terminalSize.X {
+
+			if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
 				CursorNextLine(1)
-				//fmt.Print(len(line), "index", index)
 			} else {
 				CursorForward(1)
 			}
-
 			// increment the index
 			index++
+
 		}
 	}
 }

--- a/terminal/runereader_posix.go
+++ b/terminal/runereader_posix.go
@@ -81,6 +81,18 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 			return KeyArrowUp, 1, nil
 		case 'B':
 			return KeyArrowDown, 1, nil
+		case 'H': // Home button
+			return SpecialKeyHome, 1, nil
+		case 'F': // End button
+			return SpecialKeyEnd, 1, nil
+		case '3': // Delete Button
+			// discard the following '~' key from buffer
+			rr.state.buf.Discard(1)
+			return SpecialKeyDelete, 1, nil
+		default:
+			// discard the following '~' key from buffer
+			rr.state.buf.Discard(1)
+			return IgnoreKey, 1, nil
 		}
 		return r, size, fmt.Errorf("Unknown Escape Sequence: %q", []rune{'\033', '[', r})
 	}

--- a/terminal/runereader_windows.go
+++ b/terminal/runereader_windows.go
@@ -108,7 +108,6 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 		if key.wdControlKeyState&(LEFT_CTRL_PRESSED|RIGHT_CTRL_PRESSED) != 0 && key.unicodeChar == 'C' {
 			return KeyInterrupt, bytesRead, nil
 		}
-
 		// not a normal character so look up the input sequence from the
 		// virtual key code mappings (VK_*)
 		if key.unicodeChar == 0 {

--- a/terminal/runereader_windows.go
+++ b/terminal/runereader_windows.go
@@ -18,6 +18,9 @@ const (
 
 	// key codes for arrow keys
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/dd375731(v=vs.85).aspx
+	VK_DELETE= 0x2E
+	VK_END   = 0x23
+	VK_HOME  = 0x24
 	VK_LEFT  = 0x25
 	VK_UP    = 0x26
 	VK_RIGHT = 0x27
@@ -118,6 +121,12 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 				return KeyArrowRight, bytesRead, nil
 			case VK_UP:
 				return KeyArrowUp, bytesRead, nil
+			case VK_DELETE:
+				return SpecialKeyDelete, bytesRead, nil
+			case VK_HOME:
+				return SpecialKeyHome, bytesRead, nil
+			case VK_END:
+				return SpecialKeyEnd, bytesRead, nil
 			default:
 				// not a virtual key that we care about so just continue on to
 				// the next input key

--- a/terminal/sequences.go
+++ b/terminal/sequences.go
@@ -11,9 +11,13 @@ const (
 	KeyDelete          = '\x7f'
 	KeyInterrupt       = '\x03'
 	KeyEndTransmission = '\x04'
-	KeyEscape		   = '\x1b'
+	KeyEscape          = '\x1b'
 	KeyDeleteWord      = '\x17' // Ctrl+W
 	KeyDeleteLine      = '\x18' // Ctrl+X
+	SpecialKeyHome     = '\x01'
+	SpecialKeyEnd      = '\x11'
+	SpecialKeyDelete   = '\x12'
+	IgnoreKey          = '\000'
 )
 
 func soundBell() {

--- a/tests/input.go
+++ b/tests/input.go
@@ -18,7 +18,11 @@ var table = []TestUtil.TestTableEntry{
 		"no help, send '?'", &survey.Input{Message: "Hello world"}, &val,
 	},
 	{
-		"input text in random location", &survey.Input{Message: "Hello"}, &val,
+		"Home, End Button test in random location", &survey.Input{Message: "Hello world"}, &val,
+	},{
+		"Delete and forward delete test at random location (test if screen overflows)", &survey.Input{Message: "Hello world"}, &val,
+	},{
+		"Moving around lines with left & right arrow keys", &survey.Input{Message: "Hello world"}, &val,
 	},
 }
 


### PR DESCRIPTION
When handling single line inputs the library doesn't respect delete, end, or other special keys. It just interrupts the process and exits. 

This adds Home, End, Forward delete functionality as well as improved handling of longer single line inputs ( stretching more than one line in the terminal window )

fixes #131  

