### PR TITLE
Change icons to more simple ones (Issue 93)

### DIFF
--- a/confirm_test.go
+++ b/confirm_test.go
@@ -2,6 +2,7 @@ package survey
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -29,32 +30,31 @@ func TestConfirmRender(t *testing.T) {
 			"Test Confirm question output with default true",
 			Confirm{Message: "Is pizza your favorite food?", Default: true},
 			ConfirmTemplateData{},
-			`? Is pizza your favorite food? (Y/n) `,
+			fmt.Sprintf("%s Is pizza your favorite food? (Y/n) ", core.QuestionIcon),
 		},
 		{
 			"Test Confirm question output with default false",
 			Confirm{Message: "Is pizza your favorite food?", Default: false},
 			ConfirmTemplateData{},
-			`? Is pizza your favorite food? (y/N) `,
+			fmt.Sprintf("%s Is pizza your favorite food? (y/N) ", core.QuestionIcon),
 		},
 		{
 			"Test Confirm answer output",
 			Confirm{Message: "Is pizza your favorite food?"},
 			ConfirmTemplateData{Answer: "Yes"},
-			"? Is pizza your favorite food? Yes\n",
+			fmt.Sprintf("%s Is pizza your favorite food? Yes\n", core.QuestionIcon),
 		},
 		{
 			"Test Confirm with help but help message is hidden",
 			Confirm{Message: "Is pizza your favorite food?", Help: "This is helpful"},
 			ConfirmTemplateData{},
-			"? Is pizza your favorite food? [? for help] (y/N) ",
+			fmt.Sprintf("%s Is pizza your favorite food? [%s for help] (y/N) ", core.QuestionIcon, string(core.HelpInputRune)),
 		},
 		{
 			"Test Confirm help output with help message shown",
 			Confirm{Message: "Is pizza your favorite food?", Help: "This is helpful"},
 			ConfirmTemplateData{ShowHelp: true},
-			`ⓘ This is helpful
-? Is pizza your favorite food? (y/N) `,
+			fmt.Sprintf("%s This is helpful\n%s Is pizza your favorite food? (y/N) ", core.HelpIcon, core.QuestionIcon),
 		},
 	}
 
@@ -125,7 +125,12 @@ func TestConfirmPrompt(t *testing.T) {
 				Help:    "It probably is",
 			},
 			func(c *expect.Console) {
-				c.ExpectString("Is pizza your favorite food? [? for help] (y/N)")
+				c.ExpectString(
+					fmt.Sprintf(
+						"Is pizza your favorite food? [%s for help] (y/N)",
+						string(core.HelpInputRune),
+					),
+				)
 				c.SendLine("?")
 				c.ExpectString("It probably is")
 				c.SendLine("Y")

--- a/core/template.go
+++ b/core/template.go
@@ -33,6 +33,23 @@ var (
 	SelectFocusIcon = ">"
 )
 
+/*
+  SetFancyIcons changes the err, help, marked, and focus input icons to their
+  fancier forms. These forms may not be compatible with most terminals.
+  This function will not touch the QuestionIcon as its fancy and non fancy form
+  are the same.
+*/
+func SetFancyIcons() {
+	ErrorIcon = "✘"
+	HelpIcon = "ⓘ"
+	// QuestionIcon fancy and non-fancy form are the same
+
+	MarkedOptionIcon = "◉"
+	UnmarkedOptionIcon = "◯"
+
+	SelectFocusIcon = "❯"
+}
+
 var TemplateFuncs = map[string]interface{}{
 	// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
 	"color": func(color string) string {

--- a/core/template.go
+++ b/core/template.go
@@ -11,16 +11,26 @@ import (
 var DisableColor = false
 
 var (
+	// HelpInputRune is the rune which the user should enter to trigger
+	// more detailed question help
 	HelpInputRune = '?'
 
-	ErrorIcon    = "✘"
-	HelpIcon     = "ⓘ"
+	// ErrorIcon will be be shown before an error
+	ErrorIcon = "X"
+
+	// HelpIcon will be shown before more detailed question help
+	HelpIcon = "????"
+	// QuestionIcon will be shown before a question Message
 	QuestionIcon = "?"
 
-	MarkedOptionIcon   = "◉"
-	UnmarkedOptionIcon = "◯"
+	// MarkedOptionIcon will be prepended before a selected multiselect option
+	MarkedOptionIcon = "[x]"
+	// UnmarkedOptionIcon will be prepended before an unselected multiselect option
+	UnmarkedOptionIcon = "[ ]"
 
-	SelectFocusIcon = "❯"
+	// SelectFocusIcon is prepended to an option to signify the user is
+	// currently focusing that option
+	SelectFocusIcon = ">"
 )
 
 var TemplateFuncs = map[string]interface{}{

--- a/editor_test.go
+++ b/editor_test.go
@@ -2,6 +2,7 @@ package survey
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -30,51 +31,49 @@ func TestEditorRender(t *testing.T) {
 			"Test Editor question output without default",
 			Editor{Message: "What is your favorite month:"},
 			EditorTemplateData{},
-			"? What is your favorite month: [Enter to launch editor] ",
+			fmt.Sprintf("%s What is your favorite month: [Enter to launch editor] ", core.QuestionIcon),
 		},
 		{
 			"Test Editor question output with default",
 			Editor{Message: "What is your favorite month:", Default: "April"},
 			EditorTemplateData{},
-			"? What is your favorite month: (April) [Enter to launch editor] ",
+			fmt.Sprintf("%s What is your favorite month: (April) [Enter to launch editor] ", core.QuestionIcon),
 		},
 		{
 			"Test Editor question output with HideDefault",
 			Editor{Message: "What is your favorite month:", Default: "April", HideDefault: true},
 			EditorTemplateData{},
-			"? What is your favorite month: [Enter to launch editor] ",
+			fmt.Sprintf("%s What is your favorite month: [Enter to launch editor] ", core.QuestionIcon),
 		},
 		{
 			"Test Editor answer output",
 			Editor{Message: "What is your favorite month:"},
 			EditorTemplateData{Answer: "October", ShowAnswer: true},
-			"? What is your favorite month: October\n",
+			fmt.Sprintf("%s What is your favorite month: October\n", core.QuestionIcon),
 		},
 		{
 			"Test Editor question output without default but with help hidden",
 			Editor{Message: "What is your favorite month:", Help: "This is helpful"},
 			EditorTemplateData{},
-			"? What is your favorite month: [? for help] [Enter to launch editor] ",
+			fmt.Sprintf("%s What is your favorite month: [%s for help] [Enter to launch editor] ", core.QuestionIcon, string(core.HelpInputRune)),
 		},
 		{
 			"Test Editor question output with default and with help hidden",
 			Editor{Message: "What is your favorite month:", Default: "April", Help: "This is helpful"},
 			EditorTemplateData{},
-			"? What is your favorite month: [? for help] (April) [Enter to launch editor] ",
+			fmt.Sprintf("%s What is your favorite month: [%s for help] (April) [Enter to launch editor] ", core.QuestionIcon, string(core.HelpInputRune)),
 		},
 		{
 			"Test Editor question output without default but with help shown",
 			Editor{Message: "What is your favorite month:", Help: "This is helpful"},
 			EditorTemplateData{ShowHelp: true},
-			`ⓘ This is helpful
-? What is your favorite month: [Enter to launch editor] `,
+			fmt.Sprintf("%s This is helpful\n%s What is your favorite month: [Enter to launch editor] ", core.HelpIcon, core.QuestionIcon),
 		},
 		{
 			"Test Editor question output with default and with help shown",
 			Editor{Message: "What is your favorite month:", Default: "April", Help: "This is helpful"},
 			EditorTemplateData{ShowHelp: true},
-			`ⓘ This is helpful
-? What is your favorite month: (April) [Enter to launch editor] `,
+			fmt.Sprintf("%s This is helpful\n%s What is your favorite month: (April) [Enter to launch editor] ", core.HelpIcon, core.QuestionIcon),
 		},
 	}
 
@@ -178,7 +177,12 @@ func TestEditorPrompt(t *testing.T) {
 				Help:    "Describe your git commit",
 			},
 			func(c *expect.Console) {
-				c.ExpectString("Edit git commit message [? for help] [Enter to launch editor]")
+				c.ExpectString(
+					fmt.Sprintf(
+						"Edit git commit message [%s for help] [Enter to launch editor]",
+						string(core.HelpInputRune),
+					),
+				)
 				c.SendLine("?")
 				c.ExpectString("Describe your git commit")
 				c.SendLine("")

--- a/input_test.go
+++ b/input_test.go
@@ -2,6 +2,7 @@ package survey
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -29,45 +30,43 @@ func TestInputRender(t *testing.T) {
 			"Test Input question output without default",
 			Input{Message: "What is your favorite month:"},
 			InputTemplateData{},
-			"? What is your favorite month: ",
+			fmt.Sprintf("%s What is your favorite month: ", core.QuestionIcon),
 		},
 		{
 			"Test Input question output with default",
 			Input{Message: "What is your favorite month:", Default: "April"},
 			InputTemplateData{},
-			"? What is your favorite month: (April) ",
+			fmt.Sprintf("%s What is your favorite month: (April) ", core.QuestionIcon),
 		},
 		{
 			"Test Input answer output",
 			Input{Message: "What is your favorite month:"},
 			InputTemplateData{Answer: "October", ShowAnswer: true},
-			"? What is your favorite month: October\n",
+			fmt.Sprintf("%s What is your favorite month: October\n", core.QuestionIcon),
 		},
 		{
 			"Test Input question output without default but with help hidden",
 			Input{Message: "What is your favorite month:", Help: "This is helpful"},
 			InputTemplateData{},
-			"? What is your favorite month: [? for help] ",
+			fmt.Sprintf("%s What is your favorite month: [%s for help] ", core.QuestionIcon, string(core.HelpInputRune)),
 		},
 		{
 			"Test Input question output with default and with help hidden",
 			Input{Message: "What is your favorite month:", Default: "April", Help: "This is helpful"},
 			InputTemplateData{},
-			"? What is your favorite month: [? for help] (April) ",
+			fmt.Sprintf("%s What is your favorite month: [%s for help] (April) ", core.QuestionIcon, string(core.HelpInputRune)),
 		},
 		{
 			"Test Input question output without default but with help shown",
 			Input{Message: "What is your favorite month:", Help: "This is helpful"},
 			InputTemplateData{ShowHelp: true},
-			`ⓘ This is helpful
-? What is your favorite month: `,
+			fmt.Sprintf("%s This is helpful\n%s What is your favorite month: ", core.HelpIcon, core.QuestionIcon),
 		},
 		{
 			"Test Input question output with default and with help shown",
 			Input{Message: "What is your favorite month:", Default: "April", Help: "This is helpful"},
 			InputTemplateData{ShowHelp: true},
-			`ⓘ This is helpful
-? What is your favorite month: (April) `,
+			fmt.Sprintf("%s This is helpful\n%s What is your favorite month: (April) ", core.HelpIcon, core.QuestionIcon),
 		},
 	}
 

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -2,8 +2,10 @@ package survey
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	expect "github.com/Netflix/go-expect"
@@ -42,12 +44,16 @@ func TestMultiSelectRender(t *testing.T) {
 				PageEntries:   prompt.Options,
 				Checked:       map[string]bool{"bar": true, "buz": true},
 			},
-			`? Pick your words:  [Use arrows to move, type to filter]
-  ◯  foo
-  ◉  bar
-❯ ◯  baz
-  ◉  buz
-`,
+			strings.Join(
+				[]string{
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, type to filter]", core.QuestionIcon),
+					fmt.Sprintf("  %s  foo", core.UnmarkedOptionIcon),
+					fmt.Sprintf("  %s  bar", core.MarkedOptionIcon),
+					fmt.Sprintf("%s %s  baz", core.SelectFocusIcon, core.UnmarkedOptionIcon),
+					fmt.Sprintf("  %s  buz\n", core.MarkedOptionIcon),
+				},
+				"\n",
+			),
 		},
 		{
 			"Test MultiSelect answer output",
@@ -56,7 +62,7 @@ func TestMultiSelectRender(t *testing.T) {
 				Answer:     "foo, buz",
 				ShowAnswer: true,
 			},
-			"? Pick your words: foo, buz\n",
+			fmt.Sprintf("%s Pick your words: foo, buz\n", core.QuestionIcon),
 		},
 		{
 			"Test MultiSelect question output with help hidden",
@@ -66,12 +72,16 @@ func TestMultiSelectRender(t *testing.T) {
 				PageEntries:   prompt.Options,
 				Checked:       map[string]bool{"bar": true, "buz": true},
 			},
-			`? Pick your words:  [Use arrows to move, type to filter, ? for more help]
-  ◯  foo
-  ◉  bar
-❯ ◯  baz
-  ◉  buz
-`,
+			strings.Join(
+				[]string{
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, type to filter, %s for more help]", core.QuestionIcon, string(core.HelpInputRune)),
+					fmt.Sprintf("  %s  foo", core.UnmarkedOptionIcon),
+					fmt.Sprintf("  %s  bar", core.MarkedOptionIcon),
+					fmt.Sprintf("%s %s  baz", core.SelectFocusIcon, core.UnmarkedOptionIcon),
+					fmt.Sprintf("  %s  buz\n", core.MarkedOptionIcon),
+				},
+				"\n",
+			),
 		},
 		{
 			"Test MultiSelect question output with help shown",
@@ -82,13 +92,17 @@ func TestMultiSelectRender(t *testing.T) {
 				Checked:       map[string]bool{"bar": true, "buz": true},
 				ShowHelp:      true,
 			},
-			`ⓘ This is helpful
-? Pick your words:  [Use arrows to move, type to filter]
-  ◯  foo
-  ◉  bar
-❯ ◯  baz
-  ◉  buz
-`,
+			strings.Join(
+				[]string{
+					fmt.Sprintf("%s This is helpful", core.HelpIcon),
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, type to filter]", core.QuestionIcon),
+					fmt.Sprintf("  %s  foo", core.UnmarkedOptionIcon),
+					fmt.Sprintf("  %s  bar", core.MarkedOptionIcon),
+					fmt.Sprintf("%s %s  baz", core.SelectFocusIcon, core.UnmarkedOptionIcon),
+					fmt.Sprintf("  %s  buz\n", core.MarkedOptionIcon),
+				},
+				"\n",
+			),
 		},
 	}
 

--- a/password_test.go
+++ b/password_test.go
@@ -1,6 +1,7 @@
 package survey
 
 import (
+	"fmt"
 	"testing"
 
 	expect "github.com/Netflix/go-expect"
@@ -25,20 +26,19 @@ func TestPasswordRender(t *testing.T) {
 			"Test Password question output",
 			Password{Message: "Tell me your secret:"},
 			PasswordTemplateData{},
-			"? Tell me your secret: ",
+			fmt.Sprintf("%s Tell me your secret: ", core.QuestionIcon),
 		},
 		{
 			"Test Password question output with help hidden",
 			Password{Message: "Tell me your secret:", Help: "This is helpful"},
 			PasswordTemplateData{},
-			"? Tell me your secret: [? for help] ",
+			fmt.Sprintf("%s Tell me your secret: [%s for help] ", core.QuestionIcon, string(core.HelpInputRune)),
 		},
 		{
 			"Test Password question output with help shown",
 			Password{Message: "Tell me your secret:", Help: "This is helpful"},
 			PasswordTemplateData{ShowHelp: true},
-			`ⓘ This is helpful
-? Tell me your secret: `,
+			fmt.Sprintf("%s This is helpful\n%s Tell me your secret: ", core.HelpIcon, core.QuestionIcon),
 		},
 	}
 

--- a/select_test.go
+++ b/select_test.go
@@ -2,8 +2,10 @@ package survey
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	expect "github.com/Netflix/go-expect"
@@ -38,41 +40,53 @@ func TestSelectRender(t *testing.T) {
 			"Test Select question output",
 			prompt,
 			SelectTemplateData{SelectedIndex: 2, PageEntries: prompt.Options},
-			`? Pick your word:  [Use arrows to move, type to filter]
-  foo
-  bar
-❯ baz
-  buz
-`,
+			strings.Join(
+				[]string{
+					fmt.Sprintf("%s Pick your word:  [Use arrows to move, type to filter]", core.QuestionIcon),
+					"  foo",
+					"  bar",
+					fmt.Sprintf("%s baz", core.SelectFocusIcon),
+					"  buz\n",
+				},
+				"\n",
+			),
 		},
 		{
 			"Test Select answer output",
 			prompt,
 			SelectTemplateData{Answer: "buz", ShowAnswer: true, PageEntries: prompt.Options},
-			"? Pick your word: buz\n",
+			fmt.Sprintf("%s Pick your word: buz\n", core.QuestionIcon),
 		},
 		{
 			"Test Select question output with help hidden",
 			helpfulPrompt,
 			SelectTemplateData{SelectedIndex: 2, PageEntries: prompt.Options},
-			`? Pick your word:  [Use arrows to move, type to filter, ? for more help]
-  foo
-  bar
-❯ baz
-  buz
-`,
+			strings.Join(
+				[]string{
+					fmt.Sprintf("%s Pick your word:  [Use arrows to move, type to filter, %s for more help]", core.QuestionIcon, string(core.HelpInputRune)),
+					"  foo",
+					"  bar",
+					fmt.Sprintf("%s baz", core.SelectFocusIcon),
+					"  buz\n",
+				},
+				"\n",
+			),
 		},
 		{
 			"Test Select question output with help shown",
 			helpfulPrompt,
 			SelectTemplateData{SelectedIndex: 2, ShowHelp: true, PageEntries: prompt.Options},
-			`ⓘ This is helpful
-? Pick your word:  [Use arrows to move, type to filter]
-  foo
-  bar
-❯ baz
-  buz
-`,
+			strings.Join(
+				[]string{
+					fmt.Sprintf("%s This is helpful", core.HelpIcon),
+					fmt.Sprintf("%s Pick your word:  [Use arrows to move, type to filter]", core.QuestionIcon),
+					"  foo",
+					"  bar",
+					fmt.Sprintf("%s baz", core.SelectFocusIcon),
+					"  buz\n",
+				},
+				"\n",
+			),
 		},
 	}
 

--- a/survey_test.go
+++ b/survey_test.go
@@ -206,8 +206,7 @@ func TestValidationError(t *testing.T) {
 		t.Errorf("Failed to run template to format error: %s", err)
 	}
 
-	expected := `✘ Sorry, your reply was invalid: Football is not a valid month
-`
+	expected := fmt.Sprintf("%s Sorry, your reply was invalid: Football is not a valid month\n", core.ErrorIcon)
 
 	if actual != expected {
 		t.Errorf("Formatted error was not formatted correctly. Found:\n%s\nExpected:\n%s", actual, expected)


### PR DESCRIPTION
While using your, by the way very convenient and easy to use, library in some CLI tools, I stumbled across the open issues.
So I've finished Noah-Huppert's work #93  and changed all icons to the proposed versions. I also have adjusted the tests to use string formatting instead of the hard-coded symbols. So in case we need to change the icons again in the future, it will be pretty easy.