### PR TITLE
Length counter fixed for emoji like multi byte characters

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -24,7 +24,7 @@ func MaxLength(length int) Validator {
 	return func(val interface{}) error {
 		if str, ok := val.(string); ok {
 			// if the string is longer than the given value
-			if len(str) > length {
+			if len([]rune(str)) > length {
 				// yell loudly
 				return fmt.Errorf("value is too long. Max length is %v", length)
 			}
@@ -44,7 +44,7 @@ func MinLength(length int) Validator {
 	return func(val interface{}) error {
 		if str, ok := val.(string); ok {
 			// if the string is shorter than the given value
-			if len(str) < length {
+			if len([]rune(str)) < length {
 				// yell loudly
 				return fmt.Errorf("value is too short. Min length is %v", length)
 			}

--- a/validate_test.go
+++ b/validate_test.go
@@ -93,12 +93,26 @@ func TestMaxLength(t *testing.T) {
 	if err := MaxLength(140)(testStr); err == nil {
 		t.Error("No error returned with input greater than 150 characters.")
 	}
+
+	// emoji test
+	emojiStr := "I😍Golang"
+	// validate visible length with Maxlength
+	if err := MaxLength(10)(emojiStr); err != nil {
+		t.Errorf("Error returned with emoji containing 8 characters long input.")
+	}
 }
 
 func TestMinLength(t *testing.T) {
 	// validate the string
 	if err := MinLength(12)(randString(10)); err == nil {
 		t.Error("No error returned with input less than 12 characters.")
+	}
+
+	// emoji test
+	emojiStr := "I😍Golang"
+	// validate visibly 8 characters long string with MinLength
+	if err := MinLength(10)(emojiStr); err == nil {
+		t.Error("No error returned with emoji containing input less than 10 characters.")
 	}
 }
 


### PR DESCRIPTION
In golang len counts number of bytes for strings but emojis are represented with some extra bytes in memory so this comparison gives false information.

So it has to be fixed.