### PR TITLE
Clear multi-select filter when option is selected

### DIFF
--- a/multiselect.go
+++ b/multiselect.go
@@ -27,7 +27,6 @@ type MultiSelect struct {
 	Help          string
 	PageSize      int
 	VimMode       bool
-	ClearOnSelect bool
 	FilterMessage string
 	filter        string
 	selectedIndex int
@@ -95,9 +94,7 @@ func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, 
 				// otherwise just invert the current value
 				m.checked[options[m.selectedIndex]] = !old
 			}
-			if m.ClearOnSelect {
-				m.filter = ""
-			}
+			m.filter = ""
 		}
 		// only show the help message if we have one to show
 	} else if key == core.HelpInputRune && m.Help != "" {

--- a/multiselect.go
+++ b/multiselect.go
@@ -27,6 +27,7 @@ type MultiSelect struct {
 	Help          string
 	PageSize      int
 	VimMode       bool
+	ClearOnSelect bool
 	FilterMessage string
 	filter        string
 	selectedIndex int
@@ -93,6 +94,9 @@ func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, 
 			} else {
 				// otherwise just invert the current value
 				m.checked[options[m.selectedIndex]] = !old
+			}
+			if m.ClearOnSelect {
+				m.filter = ""
 			}
 		}
 		// only show the help message if we have one to show

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -245,6 +245,27 @@ func TestMultiSelectPrompt(t *testing.T) {
 			},
 			[]string{"Tuesday"},
 		},
+		{
+			"Test MultiSelect clears input on select",
+			&MultiSelect{
+				Message: "What days do you prefer:",
+				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
+			},
+			func(c *expect.Console) {
+				c.ExpectString("What days do you prefer:  [Use arrows to move, type to filter]")
+				// Filter down to Tuesday.
+				c.Send("Tues")
+				// Select Tuesday.
+				c.Send(" ")
+				// Filter down to Tuesday.
+				c.Send("Tues")
+				// Deselect Tuesday.
+				c.Send(" ")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			[]string{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This removes the need to manually clear the filter when you want to change the input after selecting an option in multi-select.