### PR TITLE
Prompt again

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -72,7 +72,20 @@ func init() {
 	}
 }
 
+func (e *Editor) PromptAgain(invalid interface{}, err error) (interface{}, error) {
+	initialValue := invalid.(string)
+	return e.prompt(initialValue)
+}
+
 func (e *Editor) Prompt() (interface{}, error) {
+	initialValue := ""
+	if e.Default != "" && e.AppendDefault {
+		initialValue = e.Default
+	}
+	return e.prompt(initialValue)
+}
+
+func (e *Editor) prompt(initialValue string) (interface{}, error) {
 	// render the template
 	err := e.Render(
 		EditorQuestionTemplate,
@@ -134,11 +147,9 @@ func (e *Editor) Prompt() (interface{}, error) {
 		return "", err
 	}
 
-	// write default value
-	if e.Default != "" && e.AppendDefault {
-		if _, err := f.WriteString(e.Default); err != nil {
-			return "", err
-		}
+	// write initial value
+	if _, err := f.WriteString(initialValue); err != nil {
+		return "", err
 	}
 
 	// close the fd to prevent the editor unable to save file

--- a/survey.go
+++ b/survey.go
@@ -49,6 +49,11 @@ type Prompt interface {
 	Error(error) error
 }
 
+// PromptAgainer Interface for Prompts that support prompting again after invalid input
+type PromptAgainer interface {
+	PromptAgain(invalid interface{}, err error) (interface{}, error)
+}
+
 // AskOpt allows setting optional ask options.
 type AskOpt func(options *AskOptions) error
 
@@ -157,7 +162,11 @@ func Ask(qs []*Question, response interface{}, opts ...AskOpt) error {
 				}
 
 				// ask for more input
-				ans, err = q.Prompt.Prompt()
+				if promptAgainer, ok := q.Prompt.(PromptAgainer); ok {
+					ans, err = promptAgainer.PromptAgain(ans, invalid)
+				} else {
+					ans, err = q.Prompt.Prompt()
+				}
 				// if there was a problem
 				if err != nil {
 					return err


### PR DESCRIPTION
Recall the previous invalid input in the repeated Editor prompt so the user doesn't have to start over typing a long answer (for example a json structure).

Add optional PromptAgain method to Prompts to back this.