### PR TITLE
Use space to select option

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ change the global `survey.PageSize`, or set the `PageSize` field on the prompt:
 prompt := &survey.Select{..., PageSize: 10}
 ```
 
+The user can use space as well as enter to select an option by setting the `CanUseSpaceToSelect` field on the prompt:
+```golang
+prompt := &survey.Select{..., CanUseSpaceToSelect: true}
+```
+
 ### MultiSelect
 
 <img src="https://thumbs.gfycat.com/SharpTameAntelope-size_restricted.gif" width="450px"/>

--- a/select.go
+++ b/select.go
@@ -21,17 +21,18 @@ for them to select using the arrow keys and enter. Response type is a string.
 */
 type Select struct {
 	core.Renderer
-	Message       string
-	Options       []string
-	Default       string
-	Help          string
-	PageSize      int
-	VimMode       bool
-	FilterMessage string
-	filter        string
-	selectedIndex int
-	useDefault    bool
-	showingHelp   bool
+	Message             string
+	Options             []string
+	Default             string
+	Help                string
+	PageSize            int
+	VimMode             bool
+	FilterMessage       string
+	filter              string
+	selectedIndex       int
+	useDefault          bool
+	showingHelp         bool
+	CanUseSpaceToSelect bool
 }
 
 // the data available to the templates when processing
@@ -65,7 +66,7 @@ func (s *Select) OnChange(line []rune, pos int, key rune) (newLine []rune, newPo
 	oldFilter := s.filter
 
 	// if the user pressed the enter key
-	if key == terminal.KeyEnter {
+	if key == terminal.KeyEnter || (s.CanUseSpaceToSelect && key == terminal.KeySpace) {
 		if s.selectedIndex < len(options) {
 			return []rune(options[s.selectedIndex]), 0, true
 		}
@@ -231,7 +232,7 @@ func (s *Select) Prompt() (interface{}, error) {
 		if r == terminal.KeyInterrupt {
 			return "", terminal.InterruptErr
 		}
-		if r == terminal.KeyEndTransmission {
+		if r == terminal.KeyEndTransmission || (s.CanUseSpaceToSelect && r == terminal.KeySpace) {
 			break
 		}
 		s.OnChange(nil, 0, r)

--- a/select_test.go
+++ b/select_test.go
@@ -234,6 +234,21 @@ func TestSelectPrompt(t *testing.T) {
 			},
 			"red",
 		},
+		{
+			"Can use space to select option",
+			&Select{
+				Message:             "Choose a color:",
+				Options:             []string{"red", "blue", "green"},
+				CanUseSpaceToSelect: true,
+			},
+			func(c *expect.Console) {
+				c.ExpectString("Choose a color:")
+				//Select red
+				c.Send(string(terminal.KeySpace))
+				c.ExpectEOF()
+			},
+			"red",
+		},
 	}
 
 	for _, test := range tests {

--- a/tests/select.go
+++ b/tests/select.go
@@ -57,6 +57,13 @@ var goodTable = []TestUtil.TestTableEntry{
 			Options: []string{"red", "blue", "green"},
 		}, &answer, nil,
 	},
+	{
+		"can select with space", &survey.Select{
+			Message:              "Choose one:",
+			Options:              []string{"red", "blue", "green"},
+			CanUseSpaceToSelect: true,
+		}, &answer, nil,
+	},
 }
 
 var badTable = []TestUtil.TestTableEntry{


### PR DESCRIPTION
The default behaviour for a `select` is that space will append  " " to the filter.  This PR adds support to use space to select an option instead of appending to the filter.

Why? in my use case it doesn't make sense to filter on/with space. Since space is used to select/deselect in `multiselect` I also think it makes sense that it can be used select an option from an `select`. 


This PR is not related to any issues, so please feel free to do what you would like with the PR.


