### PR TITLE
Feature: allow custom filtering behavior for Select and MultiSelect

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,29 @@ change the global `survey.PageSize`, or set the `PageSize` field on the prompt:
 prompt := &survey.MultiSelect{..., PageSize: 10}
 ```
 
+### Custom filtering in Select and MultiSelect
+
+A custom filter function can be provided to change the default filtering behavior by providing a value for `FilterFn` field:
+
+```golang
+&Select{
+    Message: "Choose a color:",
+    Options: []string{"red", "blue", "green"},
+    FilterFn: func(filter string, options []string) (filtered []string) {
+        result := DefaultFilterFn(filter, options)
+        for _, v := range result {
+            if len(v) >= 5 {
+                filtered = append(filtered, v)
+            }
+        }
+        return
+    },
+}
+```
+
+While the example above is contrived, this allows for use cases where "smarter" filtering might be useful, for example, when 
+options are backed by more complex types and filtering might need to occur on more metadata than just the displayed name.
+
 ### Editor
 
 Launches the user's preferred editor (defined by the $EDITOR environment variable) on a

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,13 @@
+package survey
+
+import "strings"
+
+var DefaultFilterFn = func(filter string, options []string) (answer []string) {
+	filter = strings.ToLower(filter)
+	for _, o := range options {
+		if strings.Contains(strings.ToLower(o), filter) {
+			answer = append(answer, o)
+		}
+	}
+	return answer
+}

--- a/multiselect.go
+++ b/multiselect.go
@@ -28,6 +28,7 @@ type MultiSelect struct {
 	PageSize      int
 	VimMode       bool
 	FilterMessage string
+	FilterFn      func(string, []string) []string
 	filter        string
 	selectedIndex int
 	checked       map[string]bool
@@ -146,17 +147,13 @@ func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, 
 }
 
 func (m *MultiSelect) filterOptions() []string {
-	filter := strings.ToLower(m.filter)
-	if filter == "" {
+	if m.filter == "" {
 		return m.Options
 	}
-	answer := []string{}
-	for _, o := range m.Options {
-		if strings.Contains(strings.ToLower(o), filter) {
-			answer = append(answer, o)
-		}
+	if m.FilterFn != nil {
+		return m.FilterFn(m.filter, m.Options)
 	}
-	return answer
+	return DefaultFilterFn(m.filter, m.Options)
 }
 
 func (m *MultiSelect) Prompt() (interface{}, error) {
@@ -166,7 +163,7 @@ func (m *MultiSelect) Prompt() (interface{}, error) {
 	if len(m.Default) > 0 {
 		for _, dflt := range m.Default {
 			for _, opt := range m.Options {
-				// if the option correponds to the default
+				// if the option corresponds to the default
 				if opt == dflt {
 					// we found our initial value
 					m.checked[opt] = true

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	expect "github.com/Netflix/go-expect"
+	"github.com/Netflix/go-expect"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/AlecAivazis/survey.v1/core"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
@@ -244,6 +244,49 @@ func TestMultiSelectPrompt(t *testing.T) {
 				c.ExpectEOF()
 			},
 			[]string{"Tuesday"},
+		},
+		{
+			"Test MultiSelect prompt interaction with filter is case-insensitive",
+			&MultiSelect{
+				Message: "What days do you prefer:",
+				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
+			},
+			func(c *expect.Console) {
+				c.ExpectString("What days do you prefer:  [Use arrows to move, type to filter]")
+				// Filter down to Tuesday.
+				c.Send("tues")
+				// Select Tuesday.
+				c.Send(" ")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			[]string{"Tuesday"},
+		},
+		{
+			"Test MultiSelect prompt interaction with custom filter",
+			&MultiSelect{
+				Message: "What days do you prefer:",
+				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
+				FilterFn: func(filter string, options []string) (filtered []string) {
+					result := DefaultFilterFn(filter, options)
+					for _, v := range result {
+						if len(v) >= 7 {
+							filtered = append(filtered, v)
+						}
+					}
+					return
+				},
+			},
+			func(c *expect.Console) {
+				c.ExpectString("What days do you prefer:")
+				// Filter down to days which names are longer than 7 runes
+				c.Send("day")
+				// Select Wednesday.
+				c.Send(string(terminal.KeyArrowDown))
+				c.SendLine(" ")
+				c.ExpectEOF()
+			},
+			[]string{"Wednesday"},
 		},
 		{
 			"Test MultiSelect clears input on select",

--- a/select.go
+++ b/select.go
@@ -2,8 +2,6 @@ package survey
 
 import (
 	"errors"
-	"strings"
-
 	"gopkg.in/AlecAivazis/survey.v1/core"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
 )
@@ -59,15 +57,6 @@ var SelectQuestionTemplate = `
     {{- color "reset"}}{{"\n"}}
   {{- end}}
 {{- end}}`
-
-var DefaultFilterFn = func(filter string, options []string) (answer []string) {
-	for _, o := range options {
-		if strings.Contains(strings.ToLower(o), filter) {
-			answer = append(answer, o)
-		}
-	}
-	return answer
-}
 
 // OnChange is called on every keypress.
 func (s *Select) OnChange(line []rune, pos int, key rune) (newLine []rune, newPos int, ok bool) {
@@ -164,8 +153,7 @@ func (s *Select) OnChange(line []rune, pos int, key rune) (newLine []rune, newPo
 }
 
 func (s *Select) filterOptions() []string {
-	filter := strings.ToLower(s.filter)
-	if filter == "" {
+	if s.filter == "" {
 		return s.Options
 	}
 	if s.FilterFn != nil {
@@ -187,7 +175,7 @@ func (s *Select) Prompt() (interface{}, error) {
 	if s.Default != "" {
 		// find the choice
 		for i, opt := range s.Options {
-			// if the option correponds to the default
+			// if the option corresponds to the default
 			if opt == s.Default {
 				// we found our initial value
 				sel = i

--- a/select_test.go
+++ b/select_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	expect "github.com/Netflix/go-expect"
+	"github.com/Netflix/go-expect"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/AlecAivazis/survey.v1/core"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
@@ -220,6 +220,22 @@ func TestSelectPrompt(t *testing.T) {
 			"green",
 		},
 		{
+			"Test Select prompt interaction with filter is case-insensitive",
+			&Select{
+				Message: "Choose a color:",
+				Options: []string{"red", "blue", "green"},
+			},
+			func(c *expect.Console) {
+				c.ExpectString("Choose a color:")
+				// Filter down to red and green.
+				c.Send("RE")
+				// Select green.
+				c.SendLine(string(terminal.KeyArrowDown))
+				c.ExpectEOF()
+			},
+			"green",
+		},
+		{
 			"Can select the first result in a filtered list if there is a default",
 			&Select{
 				Message: "Choose a color:",
@@ -233,6 +249,29 @@ func TestSelectPrompt(t *testing.T) {
 				c.ExpectEOF()
 			},
 			"red",
+		},
+		{
+			"Test Select prompt interaction with custom filter",
+			&Select{
+				Message: "Choose a color:",
+				Options: []string{"red", "blue", "green"},
+				FilterFn: func(filter string, options []string) (filtered []string) {
+					result := DefaultFilterFn(filter, options)
+					for _, v := range result {
+						if len(v) >= 5 {
+							filtered = append(filtered, v)
+						}
+					}
+					return
+				},
+			},
+			func(c *expect.Console) {
+				c.ExpectString("Choose a color:")
+				// Filter down to only green since custom filter only keeps options that are longer than 5 runes
+				c.SendLine("re")
+				c.ExpectEOF()
+			},
+			"green",
 		},
 	}
 


### PR DESCRIPTION
Would allow for more complex filtering than simple substring matching (e.g. based on extra metadata in the case options are complex types instead of simple strings).