### PR TITLE
fix HelpInputRune example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ prompt := &survey.Input{
     Help:    "I couldn't come up with one.",
 }
 
-surveyCore.HelpIcon = '^'
+surveyCore.HelpInputRune = '^'
 
 survey.AskOne(prompt, &number, nil)
 ```


### PR DESCRIPTION
the example of using `HelpInputRune` mistakenly shows setting `HelpIcon` instead