### PR TITLE
Fix #170 by not using ANSI DSR on every key press

### DIFF
--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -41,14 +41,18 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 
 	// we get the terminal width and height (if resized after this point the property might become invalid)
 	terminalSize, _ := cursor.Size(rr.Buffer())
+	// we set the current location of the cursor once
+	cursorCurrent, _ := cursor.Location(rr.Buffer())
+
 	for {
 		// wait for some input
 		r, _, err := rr.ReadRune()
 		if err != nil {
 			return line, err
 		}
-		// we set the current location of the cursor and update it after every key press
-		cursorCurrent, err := cursor.Location(rr.Buffer())
+		// increment cursor location
+		cursorCurrent.X++
+
 		// if the user pressed enter or some other newline/termination like ctrl+d
 		if r == '\r' || r == '\n' || r == KeyEndTransmission {
 			// delete what's printed out on the console screen (cleanup)


### PR DESCRIPTION
Instead of using the ANSI DSR escape code on every key press, only do it
once at the beginning of reading input, and keep track of cursor
location ourselves.

In the examples below pasting some text, the speed improvement is dramatic.


Before:

![slow](https://user-images.githubusercontent.com/429763/51323266-af691880-1a35-11e9-92e1-66dd5662b357.gif)

After:

![fast](https://user-images.githubusercontent.com/429763/51323274-b4c66300-1a35-11e9-9510-a930ee1db3f0.gif)
