### PR TITLE
Removed extra empty line in render for Multiline

### DIFF
--- a/multiline.go
+++ b/multiline.go
@@ -29,7 +29,8 @@ var MultilineQuestionTemplate = `
 {{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
 {{- color "default+hb"}}{{ .Message }} {{color "reset"}}
 {{- if .ShowAnswer}}
-  {{- "\n"}}{{color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+  {{- "\n"}}{{color "cyan"}}{{.Answer}}{{color "reset"}}
+  {{- if .Answer }}{{ "\n" }}{{ end }}
 {{- else }}
   {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
   {{- color "cyan"}}[Enter 2 empty lines to finish]{{color "reset"}}

--- a/multiline_test.go
+++ b/multiline_test.go
@@ -42,7 +42,7 @@ func TestMultilineRender(t *testing.T) {
 			"Test Multiline answer output",
 			Multiline{Message: "What is your favorite month:"},
 			MultilineTemplateData{Answer: "October", ShowAnswer: true},
-			fmt.Sprintf("%s What is your favorite month: \nOctober\n", core.QuestionIcon),
+			fmt.Sprintf("%s What is your favorite month: \nOctober", core.QuestionIcon),
 		},
 		{
 			"Test Multiline question output without default but with help hidden",


### PR DESCRIPTION
Small fix for Multiline input that was rendering an extra empty line compared with the rest of input types.

Before:
```
? Code / Command

Using previous value: 'code'
```

After:
```
? Code / Command
Using previous value: 'code'
```
