### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/terminal/output.go
+++ b/terminal/output.go
@@ -6,13 +6,13 @@ import (
 	"io"
 )
 
-// Returns special stdout, which converts escape sequences to Windows API calls
+// NewAnsiStdout returns special stdout, which converts escape sequences to Windows API calls
 // on Windows environment.
 func NewAnsiStdout(out FileWriter) io.Writer {
 	return out
 }
 
-// Returns special stderr, which converts escape sequences to Windows API calls
+// NewAnsiStderr returns special stderr, which converts escape sequences to Windows API calls
 // on Windows environment.
 func NewAnsiStderr(out FileWriter) io.Writer {
 	return out


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?