### PR TITLE
Removed Validator from positional args of AskOne

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ q := &survey.Question{
 }
 ```
 
+Validators can be passed to `survey.AskOne` by using `survey.WithValidator`:
+
+```golang
+color := ""
+prompt := &survey.Input{ Message: "Whats your name?" }
+
+// you can pass multiple validators here and survey will make sure each one passes
+survey.AskOne(prompt, &color, survey.WithValidator(survey.Required))
+```
+
 ### Built-in Validators
 
 `survey` comes prepackaged with a few validators to fit common situations. Currently these

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ func (my *MyValue) WriteAnswer(name string, value interface{}) error {
 
 myval := MyValue{}
 survey.AskOne(
-    &survey.I
+    &survey.Input{
         Message: "Enter something:",
     },
     &myval,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 A library for building interactive prompts.
 
-
 <img width="550" src="https://thumbs.gfycat.com/VillainousGraciousKouprey-size_restricted.gif"/>
 
 ```go
@@ -57,7 +56,7 @@ func main() {
 }
 ```
 
-*NOTE*: This page describes the API for the upcoming `v2` release which has not been made available yet. For documentation
+_NOTE_: This page describes the API for the upcoming `v2` release which has not been made available yet. For documentation
 for the old `v1` version, see [here](https://godoc.org/gopkg.in/AlecAivazis/survey.v1).
 
 ## Table of Contents
@@ -104,7 +103,7 @@ name := ""
 prompt := &survey.Input{
     Message: "ping",
 }
-survey.AskOne(prompt, &name, nil)
+survey.AskOne(prompt, &name)
 ```
 
 ### Multiline
@@ -116,7 +115,7 @@ text := ""
 prompt := &survey.Multiline{
     Message: "ping",
 }
-survey.AskOne(prompt, &text, nil)
+survey.AskOne(prompt, &text)
 ```
 
 ### Password
@@ -128,7 +127,7 @@ password := ""
 prompt := &survey.Password{
     Message: "Please type your password",
 }
-survey.AskOne(prompt, &password, nil)
+survey.AskOne(prompt, &password)
 ```
 
 ### Confirm
@@ -140,7 +139,7 @@ name := false
 prompt := &survey.Confirm{
     Message: "Do you like pie?",
 }
-survey.AskOne(prompt, &name, nil)
+survey.AskOne(prompt, &name)
 ```
 
 ### Select
@@ -153,7 +152,7 @@ prompt := &survey.Select{
     Message: "Choose a color:",
     Options: []string{"red", "blue", "green"},
 }
-survey.AskOne(prompt, &color, nil)
+survey.AskOne(prompt, &color)
 ```
 
 The user can also press `esc` to toggle the ability cycle through the options with the j and k keys to do down and up respectively.
@@ -176,7 +175,7 @@ prompt := &survey.MultiSelect{
     Message: "What days do you prefer:",
     Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 }
-survey.AskOne(prompt, &days, nil)
+survey.AskOne(prompt, &days)
 ```
 
 The user can also press `esc` to toggle the ability cycle through the options with the j and k keys to do down and up respectively.
@@ -284,7 +283,7 @@ prompt := &survey.Input{
 
 surveyCore.HelpInputRune = '^'
 
-survey.AskOne(prompt, &number, nil)
+survey.AskOne(prompt, &number)
 ```
 
 ## Custom Types
@@ -309,7 +308,7 @@ func (my *MyValue) WriteAnswer(name string, value interface{}) error {
 
 myval := MyValue{}
 survey.AskOne(
-    &survey.Input{
+    &survey.I
         Message: "Enter something:",
     },
     &myval,

--- a/confirm.go
+++ b/confirm.go
@@ -110,7 +110,7 @@ by a carriage return.
 
 	likesPie := false
 	prompt := &survey.Confirm{ Message: "What is your name?" }
-	survey.AskOne(prompt, &likesPie, nil)
+	survey.AskOne(prompt, &likesPie)
 */
 func (c *Confirm) Prompt() (interface{}, error) {
 	// render the question template

--- a/core/template.go
+++ b/core/template.go
@@ -33,23 +33,6 @@ var (
 	SelectFocusIcon = ">"
 )
 
-/*
-  SetFancyIcons changes the err, help, marked, and focus input icons to their
-  fancier forms. These forms may not be compatible with most terminals.
-  This function will not touch the QuestionIcon as its fancy and non fancy form
-  are the same.
-*/
-func SetFancyIcons() {
-	ErrorIcon = "✘"
-	HelpIcon = "ⓘ"
-	// QuestionIcon fancy and non-fancy form are the same
-
-	MarkedOptionIcon = "◉"
-	UnmarkedOptionIcon = "◯"
-
-	SelectFocusIcon = "❯"
-}
-
 var TemplateFuncs = map[string]interface{}{
 	// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
 	"color": func(color string) string {

--- a/editor.go
+++ b/editor.go
@@ -23,7 +23,7 @@ Response type is a string.
 
 	message := ""
 	prompt := &survey.Editor{ Message: "What is your commit message?" }
-	survey.AskOne(prompt, &message, nil)
+	survey.AskOne(prompt, &message)
 */
 type Editor struct {
 	core.Renderer

--- a/input.go
+++ b/input.go
@@ -10,7 +10,7 @@ and accepts the input with the enter key. Response type is a string.
 
 	name := ""
 	prompt := &survey.Input{ Message: "What is your name?" }
-	survey.AskOne(prompt, &name, nil)
+	survey.AskOne(prompt, &name)
 */
 type Input struct {
 	core.Renderer

--- a/multiselect.go
+++ b/multiselect.go
@@ -17,7 +17,7 @@ for them to select using the arrow keys and enter. Response type is a slice of s
 		Message: "What days do you prefer:",
 		Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 	}
-	survey.AskOne(prompt, &days, nil)
+	survey.AskOne(prompt, &days)
 */
 type MultiSelect struct {
 	core.Renderer

--- a/password.go
+++ b/password.go
@@ -13,7 +13,7 @@ type is a string.
 
 	password := ""
 	prompt := &survey.Password{ Message: "Please type your password" }
-	survey.AskOne(prompt, &password, nil)
+	survey.AskOne(prompt, &password)
 */
 type Password struct {
 	core.Renderer

--- a/select.go
+++ b/select.go
@@ -16,7 +16,7 @@ for them to select using the arrow keys and enter. Response type is a string.
 		Message: "Choose a color:",
 		Options: []string{"red", "blue", "green"},
 	}
-	survey.AskOne(prompt, &color, nil)
+	survey.AskOne(prompt, &color)
 */
 type Select struct {
 	core.Renderer

--- a/tests/ask.go
+++ b/tests/ask.go
@@ -42,7 +42,7 @@ func main() {
 
 	fmt.Println("Asking one.")
 	answer := ""
-	err = survey.AskOne(simpleQs[0].Prompt, &answer, nil)
+	err = survey.AskOne(simpleQs[0].Prompt, &answer)
 	if err != nil {
 		fmt.Println(err.Error())
 		return
@@ -51,7 +51,7 @@ func main() {
 
 	fmt.Println("Asking one with validation.")
 	vAns := ""
-	err = survey.AskOne(&survey.Input{Message: "What is your name?"}, &vAns, survey.Required)
+	err = survey.AskOne(&survey.Input{Message: "What is your name?"}, &vAns, survey.WithValidator(survey.Required))
 	if err != nil {
 		fmt.Println(err.Error())
 		return

--- a/tests/longSelect.go
+++ b/tests/longSelect.go
@@ -19,5 +19,5 @@ func main() {
 			"j",
 		},
 	}
-	survey.AskOne(prompt, &color, nil)
+	survey.AskOne(prompt, &color)
 }

--- a/tests/util/test.go
+++ b/tests/util/test.go
@@ -26,7 +26,7 @@ func RunTable(table []TestTableEntry) {
 		// tell the user what we are going to ask them
 		fmt.Println(entry.Name)
 		// perform the ask
-		err := survey.AskOne(entry.Prompt, entry.Value, entry.Validate)
+		err := survey.AskOne(entry.Prompt, entry.Value, survey.WithValidator(entry.Validate))
 		if err != nil {
 			fmt.Printf("AskOne on %v's prompt failed: %v.", entry.Name, err.Error())
 			break
@@ -42,7 +42,7 @@ func RunErrorTable(table []TestTableEntry) {
 		// tell the user what we are going to ask them
 		fmt.Println(entry.Name)
 		// perform the ask
-		err := survey.AskOne(entry.Prompt, entry.Value, entry.Validate)
+		err := survey.AskOne(entry.Prompt, entry.Value, survey.WithValidator(entry.Validate))
 		if err == nil {
 			fmt.Printf("AskOne on %v's prompt didn't fail.", entry.Name)
 			break


### PR DESCRIPTION
This PR is part of the work outlined in #201 and removes the `Validator` passed as the third argument to `AskOne` in favor of an `AskOpt`. 

Since this is passed straight through to `Ask`, this does have the side effect of allowing multiple validators to be specified for a single field. However, I don't think we want to change the api of the prompts to allow for multiple Validators to be provided but I can probably be convinced otherwise.

I also removed the FancyIcon stuff since we're doing some spring cleaning