### PR TITLE
Added WithPageSize AskOpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,16 @@ The user can also press `esc` to toggle the ability cycle through the options wi
 
 By default, the select prompt is limited to showing 7 options at a time
 and will paginate lists of options longer than that. To increase, you can either
-change the global `survey.PageSize`, or set the `PageSize` field on the prompt:
+set the `PageSize` field on the prompt:
 
 ```golang
 prompt := &survey.Select{..., PageSize: 10}
+```
+
+Or pass an an `AskOpt` to `survey.Ask` or `survey.AskOne`:
+
+```golang
+survey.AskOne(prompt, &days, survey.WithPageSize(10))
 ```
 
 ### MultiSelect
@@ -182,10 +188,16 @@ The user can also press `esc` to toggle the ability cycle through the options wi
 
 By default, the MultiSelect prompt is limited to showing 7 options at a time
 and will paginate lists of options longer than that. To increase, you can either
-change the global `survey.PageSize`, or set the `PageSize` field on the prompt:
+set the `PageSize` field on the prompt:
 
 ```golang
 prompt := &survey.MultiSelect{..., PageSize: 10}
+```
+
+Or pass an an `AskOpt` to `survey.Ask` or `survey.AskOne`:
+
+```golang
+survey.AskOne(prompt, &days, survey.WithPageSize(10))
 ```
 
 ### Editor

--- a/confirm.go
+++ b/confirm.go
@@ -112,7 +112,7 @@ by a carriage return.
 	prompt := &survey.Confirm{ Message: "What is your name?" }
 	survey.AskOne(prompt, &likesPie)
 */
-func (c *Confirm) Prompt() (interface{}, error) {
+func (c *Confirm) Prompt(config *PromptConfig) (interface{}, error) {
 	// render the question template
 	err := c.Render(
 		ConfirmQuestionTemplate,

--- a/editor.go
+++ b/editor.go
@@ -77,7 +77,7 @@ func (e *Editor) PromptAgain(invalid interface{}, err error) (interface{}, error
 	return e.prompt(initialValue)
 }
 
-func (e *Editor) Prompt() (interface{}, error) {
+func (e *Editor) Prompt(config *PromptConfig) (interface{}, error) {
 	initialValue := ""
 	if e.Default != "" && e.AppendDefault {
 		initialValue = e.Default

--- a/input.go
+++ b/input.go
@@ -39,7 +39,7 @@ var InputQuestionTemplate = `
   {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
 {{- end}}`
 
-func (i *Input) Prompt() (interface{}, error) {
+func (i *Input) Prompt(config *PromptConfig) (interface{}, error) {
 	// render the template
 	err := i.Render(
 		InputQuestionTemplate,

--- a/multiline.go
+++ b/multiline.go
@@ -36,7 +36,7 @@ var MultilineQuestionTemplate = `
   {{- color "cyan"}}[Enter 2 empty lines to finish]{{color "reset"}}
 {{- end}}`
 
-func (i *Multiline) Prompt() (interface{}, error) {
+func (i *Multiline) Prompt(config *PromptConfig) (interface{}, error) {
 	// render the template
 	err := i.Render(
 		MultilineQuestionTemplate,

--- a/multiselect.go
+++ b/multiselect.go
@@ -63,7 +63,7 @@ var MultiSelectQuestionTemplate = `
 {{- end}}`
 
 // OnChange is called on every keypress.
-func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, newPos int, ok bool) {
+func (m *MultiSelect) OnChange(key rune, config *PromptConfig) {
 	options := m.filterOptions()
 	oldFilter := m.filter
 
@@ -125,10 +125,17 @@ func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, 
 		}
 	}
 	// paginate the options
+	// figure out the page size
+	pageSize := m.PageSize
+	// if we dont have a specific one
+	if pageSize == 0 {
+		// grab the global value
+		pageSize = config.PageSize
+	}
 
 	// TODO if we have started filtering and were looking at the end of a list
 	// and we have modified the filter then we should move the page back!
-	opts, idx := paginate(m.PageSize, options, m.selectedIndex)
+	opts, idx := paginate(pageSize, options, m.selectedIndex)
 
 	// render the options
 	m.Render(
@@ -141,9 +148,6 @@ func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, 
 			PageEntries:   opts,
 		},
 	)
-
-	// if we are not pressing ent
-	return line, 0, true
 }
 
 func (m *MultiSelect) filterOptions() []string {
@@ -224,7 +228,7 @@ func (m *MultiSelect) Prompt(config *PromptConfig) (interface{}, error) {
 		if r == terminal.KeyEndTransmission {
 			break
 		}
-		m.OnChange(nil, 0, r)
+		m.OnChange(r, config)
 	}
 	m.filter = ""
 	m.FilterMessage = ""

--- a/multiselect.go
+++ b/multiselect.go
@@ -180,8 +180,15 @@ func (m *MultiSelect) Prompt(config *PromptConfig) (interface{}, error) {
 		return "", errors.New("please provide options to select from")
 	}
 
+	// figure out the page size
+	pageSize := m.PageSize
+	// if we dont have a specific one
+	if pageSize == 0 {
+		// grab the global value
+		pageSize = config.PageSize
+	}
 	// paginate the options
-	opts, idx := paginate(m.PageSize, m.Options, m.selectedIndex)
+	opts, idx := paginate(pageSize, m.Options, m.selectedIndex)
 
 	cursor := m.NewCursor()
 	cursor.Hide()       // hide the cursor

--- a/multiselect.go
+++ b/multiselect.go
@@ -156,7 +156,7 @@ func (m *MultiSelect) filterOptions() []string {
 	return DefaultFilter(m.filter, m.Options)
 }
 
-func (m *MultiSelect) Prompt() (interface{}, error) {
+func (m *MultiSelect) Prompt(config *PromptConfig) (interface{}, error) {
 	// compute the default state
 	m.checked = make(map[string]bool)
 	// if there is a default

--- a/password.go
+++ b/password.go
@@ -33,7 +33,7 @@ var PasswordQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }} {{color "reset"}}
 {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}} {{end}}`
 
-func (p *Password) Prompt() (line interface{}, err error) {
+func (p *Password) Prompt(config *PromptConfig) (line interface{}, err error) {
 	// render the question template
 	out, err := core.RunTemplate(
 		PasswordQuestionTemplate,

--- a/select.go
+++ b/select.go
@@ -193,8 +193,16 @@ func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
 	// save the selected index
 	s.selectedIndex = sel
 
+	// figure out the page size
+	pageSize := s.PageSize
+	// if we dont have a specific one
+	if pageSize == 0 {
+		// grab the global value
+		pageSize = config.PageSize
+	}
+
 	// figure out the options and index to render
-	opts, idx := paginate(s.PageSize, s.Options, sel)
+	opts, idx := paginate(pageSize, s.Options, sel)
 
 	// ask the question
 	err := s.Render(

--- a/select.go
+++ b/select.go
@@ -60,7 +60,7 @@ var SelectQuestionTemplate = `
 {{- end}}`
 
 // OnChange is called on every keypress.
-func (s *Select) OnChange(key rune) bool {
+func (s *Select) OnChange(key rune, config *PromptConfig) bool {
 	options := s.filterOptions()
 	oldFilter := s.filter
 
@@ -138,10 +138,17 @@ func (s *Select) OnChange(key rune) bool {
 	}
 
 	// figure out the options and index to render
+	// figure out the page size
+	pageSize := s.PageSize
+	// if we dont have a specific one
+	if pageSize == 0 {
+		// grab the global value
+		pageSize = config.PageSize
+	}
 
 	// TODO if we have started filtering and were looking at the end of a list
 	// and we have modified the filter then we should move the page back!
-	opts, idx := paginate(s.PageSize, options, s.selectedIndex)
+	opts, idx := paginate(pageSize, options, s.selectedIndex)
 
 	// render the options
 	s.Render(
@@ -240,7 +247,7 @@ func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
 		if r == terminal.KeyEndTransmission {
 			break
 		}
-		if s.OnChange(r) {
+		if s.OnChange(r, config) {
 			break
 		}
 	}

--- a/select.go
+++ b/select.go
@@ -168,7 +168,7 @@ func (s *Select) filterOptions() []string {
 	return DefaultFilter(s.filter, s.Options)
 }
 
-func (s *Select) Prompt() (interface{}, error) {
+func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
 	// if there are no options to render
 	if len(s.Options) == 0 {
 		// we failed

--- a/survey.go
+++ b/survey.go
@@ -19,6 +19,9 @@ var DefaultAskOptions = AskOptions{
 		Out: os.Stdout,
 		Err: os.Stderr,
 	},
+	PromptConfig: PromptConfig{
+		PageSize: 7,
+	},
 }
 
 // Validator is a function passed to a Question after a user has provided a response.
@@ -41,10 +44,15 @@ type Question struct {
 	Transform Transformer
 }
 
+// PromptConfig holds the global configuration for a prompt
+type PromptConfig struct {
+	PageSize int
+}
+
 // Prompt is the primary interface for the objects that can take user input
 // and return a response.
 type Prompt interface {
-	Prompt() (interface{}, error)
+	Prompt(config *PromptConfig) (interface{}, error)
 	Cleanup(interface{}) error
 	Error(error) error
 }
@@ -59,8 +67,9 @@ type AskOpt func(options *AskOptions) error
 
 // AskOptions provides additional options on ask.
 type AskOptions struct {
-	Stdio      terminal.Stdio
-	Validators []Validator
+	Stdio        terminal.Stdio
+	Validators   []Validator
+	PromptConfig PromptConfig
 }
 
 // WithStdio specifies the standard input, output and error files survey
@@ -87,6 +96,17 @@ func WithValidator(v Validator) AskOpt {
 
 type wantsStdio interface {
 	WithStdio(terminal.Stdio)
+}
+
+// WithPageSize sets the default page size used by prompts
+func WithPageSize(pageSize int) AskOpt {
+	return func(options *AskOptions) error {
+		// set the page size
+		options.PromptConfig.PageSize = pageSize
+
+		// nothing went wrong
+		return nil
+	}
 }
 
 /*
@@ -157,7 +177,7 @@ func Ask(qs []*Question, response interface{}, opts ...AskOpt) error {
 		}
 
 		// grab the user input and save it
-		ans, err := q.Prompt.Prompt()
+		ans, err := q.Prompt.Prompt(&options.PromptConfig)
 		// if there was a problem
 		if err != nil {
 			return err
@@ -189,7 +209,7 @@ func Ask(qs []*Question, response interface{}, opts ...AskOpt) error {
 				if promptAgainer, ok := q.Prompt.(PromptAgainer); ok {
 					ans, err = promptAgainer.PromptAgain(ans, invalid)
 				} else {
-					ans, err = q.Prompt.Prompt()
+					ans, err = q.Prompt.Prompt(&options.PromptConfig)
 				}
 				// if there was a problem
 				if err != nil {

--- a/survey.go
+++ b/survey.go
@@ -9,9 +9,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 )
 
-// PageSize is the default maximum number of items to show in select/multiselect prompts
-var PageSize = 7
-
 // DefaultAskOptions is the default options on ask, using the OS stdio.
 var DefaultAskOptions = AskOptions{
 	Stdio: terminal.Stdio{
@@ -251,19 +248,7 @@ func Ask(qs []*Question, response interface{}, opts ...AskOpt) error {
 
 // paginate returns a single page of choices given the page size, the total list of
 // possible choices, and the current selected index in the total list.
-func paginate(page int, choices []string, sel int) ([]string, int) {
-	// the number of elements to show in a single page
-	var pageSize int
-	// if the select has a specific page size
-	if page != 0 {
-		// use the specified one
-		pageSize = page
-		// otherwise the select does not have a page size
-	} else {
-		// use the package default
-		pageSize = PageSize
-	}
-
+func paginate(pageSize int, choices []string, sel int) ([]string, int) {
 	var start, end, cursor int
 
 	if len(choices) < pageSize {

--- a/survey_test.go
+++ b/survey_test.go
@@ -36,7 +36,7 @@ func RunPromptTest(t *testing.T, test PromptTest) {
 		if p, ok := test.prompt.(wantsStdio); ok {
 			p.WithStdio(stdio)
 		}
-		answer, err = test.prompt.Prompt()
+		answer, err = test.prompt.Prompt(&PromptConfig{})
 		return err
 	})
 	require.Equal(t, test.expected, answer)


### PR DESCRIPTION
This PR is part of the work summarized in #201. It adds the `survey.WithPageSize` `AskOpt` that replaces the modification of `survey.PageSize` as the way to modify the default page size for prompts.

Since we now have to have a place for "global" configuration of prompts, I had to change the `Prompt` interface to include a reference to the config. 