### PR TITLE
fix(cursor): fix terminal cursor move display

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/kr/pty v1.1.4 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.8
+	github.com/mattn/go-runewidth v0.0.4
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -92,13 +92,15 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			// and we're not at the beginning of the line
 			if index > 0 && len(line) > 0 {
 
-				// get the length of the left character display
-				rw := runewidth.RuneWidth(line[index-1])
-
 				// if we are at the end of the word
 				if index == len(line) {
+
+					// get the last character display length
+					rw := runewidth.RuneWidth(line[len(line)-1])
+
 					// just remove the last letter from the internal representation
 					line = line[:len(line)-1]
+
 					// go back one
 					if cursorCurrent.X == 1 {
 						cursor.PreviousLine(1)
@@ -111,6 +113,9 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					EraseLine(rr.stdio.Out, ERASE_LINE_END)
 				} else {
 					// we need to remove a character from the middle of the word
+
+					// first, we need to get the display length of the deleted characters to move the cursor.
+					rw := runewidth.RuneWidth(line[index-1])
 
 					// remove the current index from the list
 					line = append(line[:index-1], line[index:]...)
@@ -216,7 +221,9 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					cursorCurrent.Y--
 
 				} else {
-					cursor.Back(1)
+					// get the display length of the terminal character
+					rw := runewidth.RuneWidth(line[index-1])
+					cursor.Back(rw)
 					cursorCurrent.X--
 				}
 				index--
@@ -231,7 +238,9 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					cursorCurrent.Y++
 
 				} else {
-					cursor.Forward(1)
+					// move the cursor to the right to always move the length of the currently displayed character
+					rw := runewidth.RuneWidth(line[index])
+					cursor.Forward(rw)
 					cursorCurrent.X++
 				}
 				index++

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -3,6 +3,8 @@ package terminal
 import (
 	"fmt"
 	"unicode"
+
+	"github.com/mattn/go-runewidth"
 )
 
 type RuneReader struct {
@@ -89,6 +91,10 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 		if r == KeyBackspace || r == KeyDelete {
 			// and we're not at the beginning of the line
 			if index > 0 && len(line) > 0 {
+
+				// get the length of the left character display
+				rw := runewidth.RuneWidth(line[index-1])
+
 				// if we are at the end of the word
 				if index == len(line) {
 					// just remove the last letter from the internal representation
@@ -98,7 +104,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 						cursor.PreviousLine(1)
 						cursor.Forward(int(terminalSize.X))
 					} else {
-						cursor.Back(1)
+						cursor.Back(rw)
 					}
 
 					// clear the rest of the line
@@ -115,7 +121,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					cursor.Save()
 
 					// clear the rest of the line
-					cursor.Back(1)
+					cursor.Back(rw)
 
 					// print what comes after
 					for _, char := range line[index-1:] {
@@ -136,7 +142,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 						cursor.PreviousLine(1)
 						cursor.Forward(int(terminalSize.X))
 					} else {
-						cursor.Back(1)
+						cursor.Back(rw)
 					}
 				}
 
@@ -160,7 +166,9 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					cursor.PreviousLine(1)
 					cursor.Forward(int(terminalSize.X))
 				} else {
-					cursor.Back(1)
+					// get the length of the left character display
+					rw := runewidth.RuneWidth(line[index-1])
+					cursor.Back(rw)
 				}
 				//decrement the index
 				index--
@@ -183,7 +191,9 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 				if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
 					cursor.NextLine(1)
 				} else {
-					cursor.Forward(1)
+					// get the length of the left character display
+					rw := runewidth.RuneWidth(line[index])
+					cursor.Forward(rw)
 				}
 				index++
 
@@ -306,7 +316,8 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
 				cursor.NextLine(1)
 			} else {
-				cursor.Forward(1)
+				rw := runewidth.RuneWidth(r)
+				cursor.Forward(rw)
 			}
 			// increment the index
 			index++


### PR DESCRIPTION
### fix terminal cursor move display

**I only completed the test on my terminal (iTerm2).** 

![2019-06-02 20 48 53](https://user-images.githubusercontent.com/13043245/58761738-10733200-857a-11e9-83ae-354c95c4a8a9.gif)


In the test I found that Goland's terminal seems to have problems with emoji:

Use the test string: `啊啊啊啊aaaa😀😀😀😀啊啊啊啊啊啊`

When the cursor is in the first position of emoji, the cursor appears to be abnormally jumped when trying to delete the letter `a`

- Goland
![2019-06-02 21 05 23](https://user-images.githubusercontent.com/13043245/58761761-3ef10d00-857a-11e9-9961-5a576c8670bf.gif)

- iTerm2
![2019-06-02 21 05 44](https://user-images.githubusercontent.com/13043245/58761764-40bad080-857a-11e9-9a1f-2351f77f350b.gif)


Signed-off-by: mritd <mritd@linux.com>