### PR TITLE
editor: add FileNamePattern option

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,15 @@ survey.AskOne(prompt, &days, survey.WithPageSize(10))
 
 ### Editor
 
-Launches the user's preferred editor (defined by the \$EDITOR environment variable) on a
+Launches the user's preferred editor (defined by the \$VISUAL or \$EDITOR environment variables) on a
 temporary file. Once the user exits their editor, the contents of the temporary file are read in as
 the result. If neither of those are present, notepad (on Windows) or vim (Linux or Mac) is used.
+
+You may want to specify the file name pattern for the temporary file to activate syntax highlighting in the editor.
+
+```golang
+survey.AskOne(&survey.Editor{Message: "Shell code snippet", FileNamePattern: "*.sh"}, &content)
+```
 
 ## Filtering Options
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ Launches the user's preferred editor (defined by the \$VISUAL or \$EDITOR enviro
 temporary file. Once the user exits their editor, the contents of the temporary file are read in as
 the result. If neither of those are present, notepad (on Windows) or vim (Linux or Mac) is used.
 
-You may want to specify the file name pattern for the temporary file to activate syntax highlighting in the editor.
+You may want to specify the file name [pattern](https://golang.org/pkg/io/ioutil/#TempFile) for the temporary file to
+activate syntax highlighting in the editor.
 
 ```golang
 survey.AskOne(&survey.Editor{Message: "Shell code snippet", FileNamePattern: "*.sh"}, &content)

--- a/editor.go
+++ b/editor.go
@@ -26,12 +26,13 @@ Response type is a string.
 */
 type Editor struct {
 	Renderer
-	Message       string
-	Default       string
-	Help          string
-	Editor        string
-	HideDefault   bool
-	AppendDefault bool
+	Message         string
+	Default         string
+	Help            string
+	Editor          string
+	HideDefault     bool
+	AppendDefault   bool
+	FileNamePattern string
 }
 
 // data available to the templates when processing
@@ -138,7 +139,11 @@ func (e *Editor) prompt(initialValue string, config *PromptConfig) (interface{},
 	}
 
 	// prepare the temp file
-	f, err := ioutil.TempFile("", "survey")
+	pattern := e.FileNamePattern
+	if pattern == "" {
+		pattern = "survey*.txt"
+	}
+	f, err := ioutil.TempFile("", pattern)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
You may want to specify the file name pattern for the temporary file
created to activate the proper syntax highlighting settings in the
user's editor automatically.