### PR TITLE
Add MultiInput prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ for the old `v1` version, see [here](https://godoc.org/gopkg.in/AlecAivazis/surv
 1. [Examples](#examples)
 1. [Prompts](#prompts)
    1. [Input](#input)
+   1. [MultiInput](#multiinput)
    1. [Multiline](#multiline)
    1. [Password](#password)
    1. [Confirm](#confirm)
@@ -105,6 +106,18 @@ prompt := &survey.Input{
     Message: "ping",
 }
 survey.AskOne(prompt, &name, nil)
+```
+
+### MultiInput
+
+<img src="" width="400px"/>
+
+```golang
+names := make([]string, 0)
+prompt := &survey.MultiInput{
+    Message: "Enter your friends names",
+}
+survey.AskOne(prompt, &names, nil)
 ```
 
 ### Multiline

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -24,12 +25,25 @@ var simpleQs = []*survey.Question{
 		},
 		Validate: survey.Required,
 	},
+	{
+		Name: "friends",
+		Prompt: &survey.MultiInput{
+			Message: "Enter the names of your friends:",
+		},
+		Validate: func(val interface{}) error {
+			if list, ok := val.([]string); !ok || len(list) < 1 {
+				return errors.New("there should be at least one response.")
+			}
+			return nil
+		},
+	},
 }
 
 func main() {
 	answers := struct {
-		Name  string
-		Color string
+		Name    string
+		Color   string
+		Friends []string
 	}{}
 
 	// ask the question
@@ -40,5 +54,5 @@ func main() {
 		return
 	}
 	// print the answers
-	fmt.Printf("%s chose %s.\n", answers.Name, answers.Color)
+	fmt.Printf("%s chose %s and is friends with %s.\n", answers.Name, answers.Color, answers.Friends)
 }

--- a/multiinput.go
+++ b/multiinput.go
@@ -1,0 +1,105 @@
+package survey
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/AlecAivazis/survey/v2/core"
+)
+
+/*
+MultiInput utilises the Input type to provide the user with a means of entering
+multiple values for a field. Response type is a []string.
+
+	names := make([]string, 0)
+	prompt := &survey.MultiInput{ Message: "What are your friend's names?" }
+	survey.AskOne(prompt, &names, nil)
+*/
+type MultiInput struct {
+	core.Renderer
+	Message string
+	Default []string
+	Help    string
+}
+
+// data available to the templates when processing
+type MultiInputTemplateData struct {
+	MultiInput
+	Answer     []string
+	ShowAnswer bool
+	ShowHelp   bool
+}
+
+var MultiInputQuestionTemplate = `
+{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- "  "}}{{- color "cyan"}}[Enter empty line to finish] {{color "reset"}}
+  {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
+{{- end}}`
+
+func (i *MultiInput) Prompt() (interface{}, error) {
+	// ctore answers
+	answers := make([]string, 0)
+	// current loop iteration
+	counter := 0
+
+	// render the template
+	err := i.Render(
+		MultiInputQuestionTemplate,
+		MultiInputTemplateData{MultiInput: *i},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// required to prevent the question from being removed
+	fmt.Println("")
+
+	// run a loop to accept n answers
+	for {
+		counter++
+		answer := ""
+		message := fmt.Sprintf("#%d:", counter)
+
+		prompt := &Input{
+			Message: message,
+			Help:    i.Help,
+		}
+
+		err := AskOne(prompt, &answer, nil)
+		if err != nil {
+			log.Println(err.Error())
+			return nil, err
+		}
+
+		// check if answer is the escape sequence
+		if answer == "" {
+			break
+		}
+
+		// return answers
+		answers = append(answers, answer)
+	}
+
+	// reset cursor to remove entries
+	cursor := i.NewCursor()
+	cursor.PreviousLine(counter + 1)
+
+	// if the answers are empty
+	if len(answers) == 0 {
+		// use the default value
+		return i.Default, err
+	}
+
+	return answers, nil
+}
+
+func (i *MultiInput) Cleanup(val interface{}) error {
+	return i.Render(
+		MultiInputQuestionTemplate,
+		MultiInputTemplateData{MultiInput: *i, Answer: val.([]string), ShowAnswer: true, ShowHelp: false},
+	)
+}

--- a/multiinput_test.go
+++ b/multiinput_test.go
@@ -1,0 +1,117 @@
+package survey
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/AlecAivazis/survey/v2/terminal"
+	expect "github.com/Netflix/go-expect"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	// disable color output for all prompts to simplify testing
+	core.DisableColor = true
+}
+
+func TestMultiInputRender(t *testing.T) {
+
+	tests := []struct {
+		title    string
+		prompt   MultiInput
+		data     MultiInputTemplateData
+		expected string
+	}{
+		{
+			"Test Input question output without default",
+			MultiInput{Message: "What is your favorite month:"},
+			MultiInputTemplateData{},
+			fmt.Sprintf("%s What is your favorite month: ", core.QuestionIcon),
+		},
+		{
+			"Test Input question output with default",
+			MultiInput{Message: "What is your favorite month:", Default: []string{"April"}},
+			MultiInputTemplateData{},
+			fmt.Sprintf("%s What is your favorite month: ([April]) ", core.QuestionIcon),
+		},
+		{
+			"Test Input answer output",
+			MultiInput{Message: "What is your favorite month:"},
+			MultiInputTemplateData{Answer: []string{"October"}, ShowAnswer: true},
+			fmt.Sprintf("%s What is your favorite month: [October]\n", core.QuestionIcon),
+		},
+		{
+			"Test Input question output without default but with help hidden",
+			MultiInput{Message: "What is your favorite month:", Help: "This is helpful"},
+			MultiInputTemplateData{},
+			fmt.Sprintf("%s What is your favorite month: [%s for help] ", core.QuestionIcon, string(core.HelpInputRune)),
+		},
+		{
+			"Test Input question output with default and with help hidden",
+			MultiInput{Message: "What is your favorite month:", Default: []string{"April"}, Help: "This is helpful"},
+			MultiInputTemplateData{},
+			fmt.Sprintf("%s What is your favorite month: [%s for help] ([April]) ", core.QuestionIcon, string(core.HelpInputRune)),
+		},
+		{
+			"Test Input question output without default but with help shown",
+			MultiInput{Message: "What is your favorite month:", Help: "This is helpful"},
+			MultiInputTemplateData{ShowHelp: true},
+			fmt.Sprintf("%s This is helpful\n%s What is your favorite month: ", core.HelpIcon, core.QuestionIcon),
+		},
+		{
+			"Test Input question output with default and with help shown",
+			MultiInput{Message: "What is your favorite month:", Default: []string{"April"}, Help: "This is helpful"},
+			MultiInputTemplateData{ShowHelp: true},
+			fmt.Sprintf("%s This is helpful\n%s What is your favorite month: ([April]) ", core.HelpIcon, core.QuestionIcon),
+		},
+	}
+
+	for _, test := range tests {
+		r, w, err := os.Pipe()
+		assert.Nil(t, err, test.title)
+
+		test.prompt.WithStdio(terminal.Stdio{Out: w})
+		test.data.MultiInput = test.prompt
+		err = test.prompt.Render(
+			InputQuestionTemplate,
+			test.data,
+		)
+		assert.Nil(t, err, test.title)
+
+		w.Close()
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		assert.Contains(t, buf.String(), test.expected, test.title)
+	}
+}
+
+func TestMultiInputPrompt(t *testing.T) {
+	tests := []PromptTest{
+		{
+			"Test MultiInput prompt interaction",
+			&MultiInput{
+				Message: "Enter the names of your friends:",
+			},
+			func(c *expect.Console) {
+				c.ExpectString("Enter the names of your friends:")
+				c.ExpectString("\n")
+				c.ExpectString("#1:")
+				c.SendLine("Larry Bird")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			[]string{"Larry Bird"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			RunPromptTest(t, test)
+		})
+	}
+}


### PR DESCRIPTION
This commit adds a MultiInput prompt allowing a user to enter multiple
distinct values for a question. These are then returned as a []string.
For example:

	? What are your friend's names?

Then the user is prompted for the first answer, then the second and so
on.

	? #1: Batman
	? #2: Joker
	? #3:

Then once finished they enter an empty line and the question will exit,
outputting the answers.

	? What are your friend's names? [Batman Joker]