### PR TITLE
Fix(doc): replace function by func in code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ prompt := &survey.Input{
     Help:    "I couldn't come up with one.",
 }
 
-survey.AskOne(prompt, &number, survey.WithIcons(function(icons *survey.IconSet) {
+survey.AskOne(prompt, &number, survey.WithIcons(func(icons *survey.IconSet) {
     // you can set any icons
     icons.Question.Text = "⁇"
     // for more information on formatting the icons, see here: https://github.com/mgutz/ansi#style-format


### PR DESCRIPTION
Hi,

I've spotted a little mistake in the code snippet about changing the survey icon. Here is the fix. 

Cheers,