### PR TITLE
survey: prevent panic on nil AskOpt

### DIFF
--- a/survey.go
+++ b/survey.go
@@ -253,6 +253,9 @@ func Ask(qs []*Question, response interface{}, opts ...AskOpt) error {
 	// build up the configuration options
 	options := defaultAskOptions()
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		if err := opt(options); err != nil {
 			return err
 		}


### PR DESCRIPTION
nils may remain from v1 code, and not trivial to find. Also, dynamic
generation of optional requirements is more complex than needed this
way:

```golang
opts := []survey.AskOpt{}
if required {
    opts = append(opts, survey.WithValidator(survey.Required))
}
survey.AskOne(input, &output, opts...)
```