### PR TITLE
[FIX] Mismatch a marked item on MultiSelect.

### DIFF
--- a/multiselect.go
+++ b/multiselect.go
@@ -57,7 +57,7 @@ var MultiSelectQuestionTemplate = `
   {{- "\n"}}
   {{- range $ix, $option := .PageEntries}}
     {{- if eq $ix $.SelectedIndex }}{{color $.Config.Icons.SelectFocus.Format }}{{ $.Config.Icons.SelectFocus.Text }}{{color "reset"}}{{else}} {{end}}
-    {{- if index $.Checked $ix }}{{color $.Config.Icons.MarkedOption.Format }} {{ $.Config.Icons.MarkedOption.Text }} {{else}}{{color $.Config.Icons.UnmarkedOption.Format }} {{ $.Config.Icons.UnmarkedOption.Text }} {{end}}
+    {{- if index $.Checked $option.Index }}{{color $.Config.Icons.MarkedOption.Format }} {{ $.Config.Icons.MarkedOption.Text }} {{else}}{{color $.Config.Icons.UnmarkedOption.Format }} {{ $.Config.Icons.UnmarkedOption.Text }} {{end}}
     {{- color "reset"}}
     {{- " "}}{{$option.Value}}{{"\n"}}
   {{- end}}

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -31,6 +31,12 @@ func TestMultiSelectRender(t *testing.T) {
 	helpfulPrompt := prompt
 	helpfulPrompt.Help = "This is helpful"
 
+	pagePrompt := MultiSelect{
+		Message:  "Pick your words:",
+		Options:  []string{"foo", "bar", "baz", "buz"},
+		PageSize: 2,
+	}
+
 	tests := []struct {
 		title    string
 		prompt   MultiSelect
@@ -101,6 +107,23 @@ func TestMultiSelectRender(t *testing.T) {
 					fmt.Sprintf("  %s  bar", defaultIcons().MarkedOption.Text),
 					fmt.Sprintf("%s %s  baz", defaultIcons().SelectFocus.Text, defaultIcons().UnmarkedOption.Text),
 					fmt.Sprintf("  %s  buz\n", defaultIcons().MarkedOption.Text),
+				},
+				"\n",
+			),
+		},
+		{
+			"marked on paginating",
+			pagePrompt,
+			MultiSelectTemplateData{
+				SelectedIndex: 0,
+				PageEntries:   core.OptionAnswerList(pagePrompt.Options)[1:3], /* show unmarked items(bar, baz)*/
+				Checked:       map[int]bool{0: true},                          /* foo marked */
+			},
+			strings.Join(
+				[]string{
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, space to select, type to filter]", defaultIcons().Question.Text),
+					fmt.Sprintf("%s %s  bar", defaultIcons().SelectFocus.Text, defaultIcons().UnmarkedOption.Text),
+					fmt.Sprintf("  %s  baz", defaultIcons().UnmarkedOption.Text),
 				},
 				"\n",
 			),


### PR DESCRIPTION
First off, it is a great library.  I have used this library very well.

The issue that i'm using the MultiSelect is that marked items mismatch when a cursor is moving on paginating items.
I have many items, so i should paginate items.

it seems the MultiSelect should compare an index on an option, not index on for-loop(PageEntries). 

please check this. thanks.