### PR TITLE
Now option answer can be transformed by this new fn

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -1,6 +1,7 @@
 package survey
 
 import (
+	"github.com/AlecAivazis/survey/v2/core"
 	"reflect"
 	"strings"
 )
@@ -28,6 +29,28 @@ func TransformString(f func(s string) string) Transformer {
 		// see survey.go#L97 for more.
 		// Make sure that the the answer's value was a typeof string.
 		s, ok := ans.(string)
+		if !ok {
+			return nil
+		}
+
+		return f(s)
+	}
+}
+
+// Helper function to transform an answer option
+func TransformOption(f func(s core.OptionAnswer) core.OptionAnswer) Transformer {
+	return func(ans interface{}) interface{} {
+		// if the answer value passed in is the zero value of the appropriate type
+		if isZero(reflect.ValueOf(ans)) {
+			// skip this `Transformer` by returning a nil value.
+			// The original answer will be not affected,
+			// see survey.go#L125.
+			return nil
+		}
+
+		// "ans" is never nil here, so we don't have to check that
+		// see survey.go#L97 for more.
+		s, ok := ans.(core.OptionAnswer)
 		if !ok {
 			return nil
 		}


### PR DESCRIPTION
Example,

```
{
		Name: "month",
		Prompt: &survey.Select{
			Message: "Month",
			Options: []string{
				"January - 01",
				"February - 02",
				"March - 03",
				"April - 04",
				"May - 05",
				"June - 06",
				"July - 07",
				"August - 08",
				"September - 09",
				"October - 10",
				"November - 11",
				"December - 12",

			},
		},
		Transform: survey.TransformOption(func(s core.OptionAnswer) core.OptionAnswer {
			s.Value = s.Value[len(s.Value)-2:]
			return s
		}),
	},
```