### PR TITLE
Cherry-pick: Change selection prompt from space to enter.

### DIFF
--- a/multiselect.go
+++ b/multiselect.go
@@ -52,7 +52,7 @@ var MultiSelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
-	{{- "  "}}{{- color "cyan"}}[Use arrows to move, space to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
+	{{- "  "}}{{- color "cyan"}}[Use arrows to move, enter to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $option := .PageEntries}}
     {{- if eq $ix $.SelectedIndex}}{{color "cyan"}}{{ SelectFocusIcon }}{{color "reset"}}{{else}} {{end}}

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -46,7 +46,7 @@ func TestMultiSelectRender(t *testing.T) {
 			},
 			strings.Join(
 				[]string{
-					fmt.Sprintf("%s Pick your words:  [Use arrows to move, space to select, type to filter]", core.QuestionIcon),
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, enter to select, type to filter]", core.QuestionIcon),
 					fmt.Sprintf("  %s  foo", core.UnmarkedOptionIcon),
 					fmt.Sprintf("  %s  bar", core.MarkedOptionIcon),
 					fmt.Sprintf("%s %s  baz", core.SelectFocusIcon, core.UnmarkedOptionIcon),
@@ -74,7 +74,7 @@ func TestMultiSelectRender(t *testing.T) {
 			},
 			strings.Join(
 				[]string{
-					fmt.Sprintf("%s Pick your words:  [Use arrows to move, space to select, type to filter, %s for more help]", core.QuestionIcon, string(core.HelpInputRune)),
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, enter to select, type to filter, %s for more help]", core.QuestionIcon, string(core.HelpInputRune)),
 					fmt.Sprintf("  %s  foo", core.UnmarkedOptionIcon),
 					fmt.Sprintf("  %s  bar", core.MarkedOptionIcon),
 					fmt.Sprintf("%s %s  baz", core.SelectFocusIcon, core.UnmarkedOptionIcon),
@@ -95,7 +95,7 @@ func TestMultiSelectRender(t *testing.T) {
 			strings.Join(
 				[]string{
 					fmt.Sprintf("%s This is helpful", core.HelpIcon),
-					fmt.Sprintf("%s Pick your words:  [Use arrows to move, space to select, type to filter]", core.QuestionIcon),
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, enter to select, type to filter]", core.QuestionIcon),
 					fmt.Sprintf("  %s  foo", core.UnmarkedOptionIcon),
 					fmt.Sprintf("  %s  bar", core.MarkedOptionIcon),
 					fmt.Sprintf("%s %s  baz", core.SelectFocusIcon, core.UnmarkedOptionIcon),
@@ -135,7 +135,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
 				// Select Monday.
 				c.Send(string(terminal.KeyArrowDown))
 				c.SendLine(" ")
@@ -151,7 +151,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Default: []string{"Tuesday", "Thursday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
 				c.SendLine("")
 				c.ExpectEOF()
 			},
@@ -165,7 +165,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Default: []string{"Tuesday", "Thursday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
 				// Deselect Tuesday.
 				c.Send(string(terminal.KeyArrowDown))
 				c.Send(string(terminal.KeyArrowDown))
@@ -182,7 +182,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Help:    "Saturday is best",
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter, ? for more help]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter, ? for more help]")
 				c.Send("?")
 				c.ExpectString("Saturday is best")
 				// Select Saturday
@@ -200,7 +200,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				PageSize: 1,
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
 				// Select Monday.
 				c.Send(string(terminal.KeyArrowDown))
 				c.SendLine(" ")
@@ -216,7 +216,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				VimMode: true,
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
 				// Select Tuesday.
 				c.Send("jj ")
 				// Select Thursday.
@@ -235,7 +235,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
 				// Filter down to Tuesday.
 				c.Send("Tues")
 				// Select Tuesday.
@@ -252,7 +252,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
 				// Filter down to Tuesday.
 				c.Send("tues")
 				// Select Tuesday.
@@ -295,7 +295,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
 				// Filter down to Tuesday.
 				c.Send("Tues")
 				// Select Tuesday.

--- a/select.go
+++ b/select.go
@@ -50,7 +50,7 @@ var SelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else}}
-  {{- "  "}}{{- color "cyan"}}[Use arrows to move, space to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
+  {{- "  "}}{{- color "cyan"}}[Use arrows to move, enter to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $choice := .PageEntries}}
     {{- if eq $ix $.SelectedIndex}}{{color "cyan+b"}}{{ SelectFocusIcon }} {{else}}{{color "default+hb"}}  {{end}}

--- a/select_test.go
+++ b/select_test.go
@@ -42,7 +42,7 @@ func TestSelectRender(t *testing.T) {
 			SelectTemplateData{SelectedIndex: 2, PageEntries: prompt.Options},
 			strings.Join(
 				[]string{
-					fmt.Sprintf("%s Pick your word:  [Use arrows to move, space to select, type to filter]", core.QuestionIcon),
+					fmt.Sprintf("%s Pick your word:  [Use arrows to move, enter to select, type to filter]", core.QuestionIcon),
 					"  foo",
 					"  bar",
 					fmt.Sprintf("%s baz", core.SelectFocusIcon),
@@ -63,7 +63,7 @@ func TestSelectRender(t *testing.T) {
 			SelectTemplateData{SelectedIndex: 2, PageEntries: prompt.Options},
 			strings.Join(
 				[]string{
-					fmt.Sprintf("%s Pick your word:  [Use arrows to move, space to select, type to filter, %s for more help]", core.QuestionIcon, string(core.HelpInputRune)),
+					fmt.Sprintf("%s Pick your word:  [Use arrows to move, enter to select, type to filter, %s for more help]", core.QuestionIcon, string(core.HelpInputRune)),
 					"  foo",
 					"  bar",
 					fmt.Sprintf("%s baz", core.SelectFocusIcon),
@@ -79,7 +79,7 @@ func TestSelectRender(t *testing.T) {
 			strings.Join(
 				[]string{
 					fmt.Sprintf("%s This is helpful", core.HelpIcon),
-					fmt.Sprintf("%s Pick your word:  [Use arrows to move, space to select, type to filter]", core.QuestionIcon),
+					fmt.Sprintf("%s Pick your word:  [Use arrows to move, enter to select, type to filter]", core.QuestionIcon),
 					"  foo",
 					"  bar",
 					fmt.Sprintf("%s baz", core.SelectFocusIcon),

--- a/survey_test.go
+++ b/survey_test.go
@@ -136,7 +136,7 @@ func TestAsk(t *testing.T) {
 				c.SendLine("Johnny Appleseed")
 
 				// MultiSelect
-				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
 				// Select Monday.
 				c.Send(string(terminal.KeyArrowDown))
 				c.Send(" ")
@@ -151,7 +151,7 @@ func TestAsk(t *testing.T) {
 				c.SendLine("")
 
 				// Select
-				c.ExpectString("Choose a color:  [Use arrows to move, space to select, type to filter]")
+				c.ExpectString("Choose a color:  [Use arrows to move, enter to select, type to filter]")
 				c.SendLine("yellow")
 				c.ExpectEOF()
 			},


### PR DESCRIPTION
Cherry-pick this to V1. We will be upgrading master branch of our project to Go modules and upgrading to V2 soon, but older releases will be stuck on V1. 

When using select or multiselect, the user is prompted to make a selection using space, but entering space causes results to be filtered by space. This commit updates the prompt to tell users to make a selection using the enter key.