### PR TITLE
update multiselect help text

### DIFF
--- a/multiselect.go
+++ b/multiselect.go
@@ -53,7 +53,7 @@ var MultiSelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
-	{{- "  "}}{{- color "cyan"}}[Use arrows to move, enter to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
+	{{- "  "}}{{- color "cyan"}}[Use arrows to move, space to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $option := .PageEntries}}
     {{- if eq $ix $.SelectedIndex }}{{color $.Config.Icons.SelectFocus.Format }}{{ $.Config.Icons.SelectFocus.Text }}{{color "reset"}}{{else}} {{end}}

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -53,7 +53,7 @@ func TestMultiSelectRender(t *testing.T) {
 			},
 			strings.Join(
 				[]string{
-					fmt.Sprintf("%s Pick your words:  [Use arrows to move, enter to select, type to filter]", defaultIcons().Question.Text),
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, space to select, type to filter]", defaultIcons().Question.Text),
 					fmt.Sprintf("  %s  foo", defaultIcons().UnmarkedOption.Text),
 					fmt.Sprintf("  %s  bar", defaultIcons().MarkedOption.Text),
 					fmt.Sprintf("%s %s  baz", defaultIcons().SelectFocus.Text, defaultIcons().UnmarkedOption.Text),
@@ -81,7 +81,7 @@ func TestMultiSelectRender(t *testing.T) {
 			},
 			strings.Join(
 				[]string{
-					fmt.Sprintf("%s Pick your words:  [Use arrows to move, enter to select, type to filter, %s for more help]", defaultIcons().Question.Text, string(defaultPromptConfig().HelpInput)),
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, space to select, type to filter, %s for more help]", defaultIcons().Question.Text, string(defaultPromptConfig().HelpInput)),
 					fmt.Sprintf("  %s  foo", defaultIcons().UnmarkedOption.Text),
 					fmt.Sprintf("  %s  bar", defaultIcons().MarkedOption.Text),
 					fmt.Sprintf("%s %s  baz", defaultIcons().SelectFocus.Text, defaultIcons().UnmarkedOption.Text),
@@ -102,7 +102,7 @@ func TestMultiSelectRender(t *testing.T) {
 			strings.Join(
 				[]string{
 					fmt.Sprintf("%s This is helpful", defaultIcons().Help.Text),
-					fmt.Sprintf("%s Pick your words:  [Use arrows to move, enter to select, type to filter]", defaultIcons().Question.Text),
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, space to select, type to filter]", defaultIcons().Question.Text),
 					fmt.Sprintf("  %s  foo", defaultIcons().UnmarkedOption.Text),
 					fmt.Sprintf("  %s  bar", defaultIcons().MarkedOption.Text),
 					fmt.Sprintf("%s %s  baz", defaultIcons().SelectFocus.Text, defaultIcons().UnmarkedOption.Text),
@@ -121,7 +121,7 @@ func TestMultiSelectRender(t *testing.T) {
 			},
 			strings.Join(
 				[]string{
-					fmt.Sprintf("%s Pick your words:  [Use arrows to move, enter to select, type to filter]", defaultIcons().Question.Text),
+					fmt.Sprintf("%s Pick your words:  [Use arrows to move, space to select, type to filter]", defaultIcons().Question.Text),
 					fmt.Sprintf("%s %s  bar", defaultIcons().SelectFocus.Text, defaultIcons().UnmarkedOption.Text),
 					fmt.Sprintf("  %s  baz", defaultIcons().UnmarkedOption.Text),
 				},
@@ -163,7 +163,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				// Select Monday.
 				c.Send(string(terminal.KeyArrowDown))
 				c.SendLine(" ")
@@ -179,7 +179,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Default: []string{"Tuesday", "Thursday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				c.SendLine("")
 				c.ExpectEOF()
 			},
@@ -196,7 +196,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Default: []int{2, 4},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				c.SendLine("")
 				c.ExpectEOF()
 			},
@@ -213,7 +213,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Default: []string{"Tuesday", "Thursday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				// Deselect Tuesday.
 				c.Send(string(terminal.KeyArrowDown))
 				c.Send(string(terminal.KeyArrowDown))
@@ -230,7 +230,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Help:    "Saturday is best",
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter, ? for more help]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter, ? for more help]")
 				c.Send("?")
 				c.ExpectString("Saturday is best")
 				// Select Saturday
@@ -248,7 +248,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				PageSize: 1,
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				// Select Monday.
 				c.Send(string(terminal.KeyArrowDown))
 				c.SendLine(" ")
@@ -264,7 +264,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				VimMode: true,
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				// Select Tuesday.
 				c.Send("jj ")
 				// Select Thursday.
@@ -287,7 +287,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				// Filter down to Tuesday.
 				c.Send("Tues")
 				// Select Tuesday.
@@ -304,7 +304,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				// Filter down to Tuesday.
 				c.Send("tues")
 				// Select Tuesday.
@@ -341,7 +341,7 @@ func TestMultiSelectPrompt(t *testing.T) {
 				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What days do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				// Filter down to Tuesday.
 				c.Send("Tues")
 				// Select Tuesday.
@@ -373,7 +373,7 @@ func TestMultiSelectPromptKeepFilter(t *testing.T) {
 				Options: []string{"green", "red", "light-green", "blue", "black", "yellow", "purple"},
 			},
 			func(c *expect.Console) {
-				c.ExpectString("What color do you prefer:  [Use arrows to move, enter to select, type to filter]")
+				c.ExpectString("What color do you prefer:  [Use arrows to move, space to select, type to filter]")
 				// Filter down to green
 				c.Send("green")
 				// Select green.


### PR DESCRIPTION
This PR fixes #280 by fixing the help text in `MultiSelect` to properly reflect the interaction (space to select, enter to submit)