### PR TITLE
udpate godoc link to use pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Survey
 
 [![Build Status](https://travis-ci.org/AlecAivazis/survey.svg?branch=feature%2Fpretty)](https://travis-ci.org/AlecAivazis/survey)
-[![GoDoc](http://img.shields.io/badge/godoc-reference-5272B4.svg)](https://godoc.org/github.com/AlecAivazis/survey)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-5272B4.svg)](https://pkg.go.dev/github.com/AlecAivazis/survey/v2)
 
 A library for building interactive prompts.
 


### PR DESCRIPTION
godoc.org does not understand the `/v2` go.mod import syntax so browsing the documentation returns errors.  pkg.go.dev is now recommended (and supports go.mod imports)