### PR TITLE
[WIP] Failing test for default not in options in Select prompt

### DIFF
--- a/select_test.go
+++ b/select_test.go
@@ -165,6 +165,22 @@ func TestSelectPrompt(t *testing.T) {
 			core.OptionAnswer{Index: 2, Value: "green"},
 		},
 		{
+			"default not in options",
+			&Select{
+				Message: "Choose a color:",
+				Options: []string{"red", "blue", "green"},
+				Default: "",
+			},
+			func(c *expect.Console) {
+				c.ExpectString("Choose a color:")
+				// Select default.
+				c.SendLine(string(terminal.KeyEnter))
+				c.ExpectString("red")
+				c.ExpectEOF()
+			},
+			core.OptionAnswer{Index: 0, Value: "red"},
+		},
+		{
 			"overriding default",
 			&Select{
 				Message: "Choose a color:",


### PR DESCRIPTION
Hi @AlecAivazis the behavior of the Select prompt when the default value is not one of the options is a bit counter intuitive. I have added a test that shows the failure.

For a select with options "one", "two", default="invalid default" the user sees:

```
Pick one option:
> one
  two
```

And if they hit enter, the resulting value is "invalid default"

What would be the preferred behavior? Thoughs:
- Ignore the default and return item at index 0
- Validate that the default is in the options and return an error if it is not.

