### PR TITLE
Fix prompt reset on some terminals

### DIFF
--- a/confirm.go
+++ b/confirm.go
@@ -59,7 +59,7 @@ func (c *Confirm) getBool(showHelp bool, config *PromptConfig) (bool, error) {
 			return false, err
 		}
 		// move back up a line to compensate for the \n echoed from terminal
-		cursor.PreviousLine(1)
+		cursor.Up(1)
 		val := string(line)
 
 		// get the answer that matches the

--- a/input.go
+++ b/input.go
@@ -64,7 +64,7 @@ func (i *Input) Prompt(config *PromptConfig) (interface{}, error) {
 			return string(line), err
 		}
 		// terminal will echo the \n so we need to jump back up one row
-		cursor.PreviousLine(1)
+		cursor.Up(1)
 
 		if string(line) == config.HelpInput && i.Help != "" {
 			err = i.Render(

--- a/multiline.go
+++ b/multiline.go
@@ -69,12 +69,12 @@ func (i *Multiline) Prompt(config *PromptConfig) (interface{}, error) {
 		if string(line) == "" {
 			if emptyOnce {
 				numLines := len(multiline) + 2
-				cursor.PreviousLine(numLines)
+				cursor.Up(numLines)
 				for j := 0; j < numLines; j++ {
 					terminal.EraseLine(i.Stdio().Out, terminal.ERASE_LINE_ALL)
-					cursor.NextLine(1)
+					cursor.Down(1)
 				}
-				cursor.PreviousLine(numLines)
+				cursor.Up(numLines)
 				break
 			}
 			emptyOnce = true

--- a/password.go
+++ b/password.go
@@ -71,7 +71,7 @@ func (p *Password) Prompt(config *PromptConfig) (interface{}, error) {
 
 		if string(line) == config.HelpInput {
 			// terminal will echo the \n so we need to jump back up one row
-			cursor.PreviousLine(1)
+			cursor.Up(1)
 
 			err = p.Render(
 				PasswordQuestionTemplate,

--- a/renderer.go
+++ b/renderer.go
@@ -112,7 +112,7 @@ func (r *Renderer) resetPrompt(lines int) {
 	terminal.EraseLine(r.stdio.Out, terminal.ERASE_LINE_ALL)
 	// clean up what we left behind last time
 	for i := 0; i < lines; i++ {
-		cursor.PreviousLine(1)
+		cursor.Up(1)
 		terminal.EraseLine(r.stdio.Out, terminal.ERASE_LINE_ALL)
 	}
 }

--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -40,16 +40,6 @@ func (c *Cursor) Back(n int) {
 	fmt.Fprintf(c.Out, "\x1b[%dD", n)
 }
 
-// NextLine moves cursor to beginning of the line n lines down.
-func (c *Cursor) NextLine(n int) {
-	fmt.Fprintf(c.Out, "\x1b[%dE", n)
-}
-
-// PreviousLine moves cursor to beginning of the line n lines up.
-func (c *Cursor) PreviousLine(n int) {
-	fmt.Fprintf(c.Out, "\x1b[%dF", n)
-}
-
 // HorizontalAbsolute moves cursor horizontally to x.
 func (c *Cursor) HorizontalAbsolute(x int) {
 	fmt.Fprintf(c.Out, "\x1b[%dG", x)
@@ -86,7 +76,7 @@ func (c *Cursor) MoveNextLine(cur *Coord, terminalSize *Coord) {
 	if cur.Y == terminalSize.Y {
 		fmt.Fprintln(c.Out)
 	}
-	c.NextLine(1)
+	c.Down(1)
 }
 
 // Location returns the current location of the cursor in the terminal

--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -40,6 +40,18 @@ func (c *Cursor) Back(n int) {
 	fmt.Fprintf(c.Out, "\x1b[%dD", n)
 }
 
+// NextLine moves cursor to beginning of the line n lines down.
+// DEPRECATED: use Down() instead
+func (c *Cursor) NextLine(n int) {
+	fmt.Fprintf(c.Out, "\x1b[%dE", n)
+}
+
+// PreviousLine moves cursor to beginning of the line n lines up.
+// DEPRECATED: use Up() instead
+func (c *Cursor) PreviousLine(n int) {
+	fmt.Fprintf(c.Out, "\x1b[%dF", n)
+}
+
 // HorizontalAbsolute moves cursor horizontally to x.
 func (c *Cursor) HorizontalAbsolute(x int) {
 	fmt.Fprintf(c.Out, "\x1b[%dG", x)

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -61,7 +61,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			for index > 0 {
 				if cursorCurrent.CursorIsAtLineBegin() {
 					EraseLine(rr.stdio.Out, ERASE_LINE_END)
-					cursor.PreviousLine(1)
+					cursor.Up(1)
 					cursor.Forward(int(terminalSize.X))
 					cursorCurrent.X = terminalSize.X
 					cursorCurrent.Y--
@@ -99,7 +99,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					line = line[:len(line)-1]
 					// go back one
 					if cursorCurrent.X == 1 {
-						cursor.PreviousLine(1)
+						cursor.Up(1)
 						cursor.Forward(int(terminalSize.X))
 					} else {
 						cursor.Back(cells)
@@ -133,13 +133,13 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					}
 					// erase what's left over from last print
 					if cursorCurrent.Y < terminalSize.Y {
-						cursor.NextLine(1)
+						cursor.Down(1)
 						EraseLine(rr.stdio.Out, ERASE_LINE_END)
 					}
 					// restore cursor
 					cursor.Restore()
 					if cursorCurrent.CursorIsAtLineBegin() {
-						cursor.PreviousLine(1)
+						cursor.Up(1)
 						cursor.Forward(int(terminalSize.X))
 					} else {
 						cursor.Back(cells)
@@ -163,7 +163,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			if index > 0 {
 				//move the cursor to the prev line if necessary
 				if cursorCurrent.CursorIsAtLineBegin() {
-					cursor.PreviousLine(1)
+					cursor.Up(1)
 					cursor.Forward(int(terminalSize.X))
 				} else {
 					cursor.Back(runeWidth(line[index-1]))
@@ -187,7 +187,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			if index < len(line) {
 				// move the cursor to the next line if necessary
 				if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
-					cursor.NextLine(1)
+					cursor.Down(1)
 				} else {
 					cursor.Forward(runeWidth(line[index]))
 				}
@@ -206,7 +206,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 		if r == SpecialKeyHome {
 			for index > 0 {
 				if cursorCurrent.CursorIsAtLineBegin() {
-					cursor.PreviousLine(1)
+					cursor.Up(1)
 					cursor.Forward(int(terminalSize.X))
 					cursorCurrent.X = terminalSize.X
 					cursorCurrent.Y--
@@ -222,7 +222,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 		} else if r == SpecialKeyEnd {
 			for index != len(line) {
 				if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
-					cursor.NextLine(1)
+					cursor.Down(1)
 					cursorCurrent.X = COORDINATE_SYSTEM_BEGIN
 					cursorCurrent.Y++
 
@@ -251,7 +251,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 				}
 				// erase what's left on last line
 				if cursorCurrent.Y < terminalSize.Y {
-					cursor.NextLine(1)
+					cursor.Down(1)
 					EraseLine(rr.stdio.Out, ERASE_LINE_END)
 				}
 				// restore cursor
@@ -310,7 +310,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			// check if cursor needs to move to next line
 			cursorCurrent, _ = cursor.Location(rr.Buffer())
 			if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
-				cursor.NextLine(1)
+				cursor.Down(1)
 			} else {
 				cursor.Forward(runeWidth(r))
 			}


### PR DESCRIPTION
fixes #300 

`PreviousLine()` prints `\e[1F`, which is apparently not recognized by Konsole. I didn't find this control code anywhere in VT100 and ANSI references.
On the other hand, `Up()` writes `\e[1A`, which works as expected. Using this makes it work perfectly in both the VSCode integrated terminal and Konsole. 

**This would require a little bit of testing on Windows and MacOS though,** but I don't expect this change to break anything.