### PR TITLE
reverted konsole support which broke runereader

### DIFF
--- a/confirm.go
+++ b/confirm.go
@@ -59,7 +59,7 @@ func (c *Confirm) getBool(showHelp bool, config *PromptConfig) (bool, error) {
 			return false, err
 		}
 		// move back up a line to compensate for the \n echoed from terminal
-		cursor.Up(1)
+		cursor.PreviousLine(1)
 		val := string(line)
 
 		// get the answer that matches the

--- a/multiline.go
+++ b/multiline.go
@@ -69,12 +69,12 @@ func (i *Multiline) Prompt(config *PromptConfig) (interface{}, error) {
 		if string(line) == "" {
 			if emptyOnce {
 				numLines := len(multiline) + 2
-				cursor.Up(numLines)
+				cursor.PreviousLine(numLines)
 				for j := 0; j < numLines; j++ {
 					terminal.EraseLine(i.Stdio().Out, terminal.ERASE_LINE_ALL)
-					cursor.Down(1)
+					cursor.NextLine(1)
 				}
-				cursor.Up(numLines)
+				cursor.PreviousLine(numLines)
 				break
 			}
 			emptyOnce = true

--- a/password.go
+++ b/password.go
@@ -71,7 +71,7 @@ func (p *Password) Prompt(config *PromptConfig) (interface{}, error) {
 
 		if string(line) == config.HelpInput {
 			// terminal will echo the \n so we need to jump back up one row
-			cursor.Up(1)
+			cursor.PreviousLine(1)
 
 			err = p.Render(
 				PasswordQuestionTemplate,

--- a/renderer.go
+++ b/renderer.go
@@ -112,7 +112,7 @@ func (r *Renderer) resetPrompt(lines int) {
 	terminal.EraseLine(r.stdio.Out, terminal.ERASE_LINE_ALL)
 	// clean up what we left behind last time
 	for i := 0; i < lines; i++ {
-		cursor.Up(1)
+		cursor.PreviousLine(1)
 		terminal.EraseLine(r.stdio.Out, terminal.ERASE_LINE_ALL)
 	}
 }

--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -41,13 +41,11 @@ func (c *Cursor) Back(n int) {
 }
 
 // NextLine moves cursor to beginning of the line n lines down.
-// DEPRECATED: use Down() instead
 func (c *Cursor) NextLine(n int) {
 	fmt.Fprintf(c.Out, "\x1b[%dE", n)
 }
 
 // PreviousLine moves cursor to beginning of the line n lines up.
-// DEPRECATED: use Up() instead
 func (c *Cursor) PreviousLine(n int) {
 	fmt.Fprintf(c.Out, "\x1b[%dF", n)
 }
@@ -88,7 +86,7 @@ func (c *Cursor) MoveNextLine(cur *Coord, terminalSize *Coord) {
 	if cur.Y == terminalSize.Y {
 		fmt.Fprintln(c.Out)
 	}
-	c.Down(1)
+	c.NextLine(1)
 }
 
 // Location returns the current location of the cursor in the terminal

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -61,7 +61,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			for index > 0 {
 				if cursorCurrent.CursorIsAtLineBegin() {
 					EraseLine(rr.stdio.Out, ERASE_LINE_END)
-					cursor.Up(1)
+					cursor.PreviousLine(1)
 					cursor.Forward(int(terminalSize.X))
 					cursorCurrent.X = terminalSize.X
 					cursorCurrent.Y--
@@ -99,7 +99,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					line = line[:len(line)-1]
 					// go back one
 					if cursorCurrent.X == 1 {
-						cursor.Up(1)
+						cursor.PreviousLine(1)
 						cursor.Forward(int(terminalSize.X))
 					} else {
 						cursor.Back(cells)
@@ -133,13 +133,13 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 					}
 					// erase what's left over from last print
 					if cursorCurrent.Y < terminalSize.Y {
-						cursor.Down(1)
+						cursor.NextLine(1)
 						EraseLine(rr.stdio.Out, ERASE_LINE_END)
 					}
 					// restore cursor
 					cursor.Restore()
 					if cursorCurrent.CursorIsAtLineBegin() {
-						cursor.Up(1)
+						cursor.PreviousLine(1)
 						cursor.Forward(int(terminalSize.X))
 					} else {
 						cursor.Back(cells)
@@ -163,7 +163,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			if index > 0 {
 				//move the cursor to the prev line if necessary
 				if cursorCurrent.CursorIsAtLineBegin() {
-					cursor.Up(1)
+					cursor.PreviousLine(1)
 					cursor.Forward(int(terminalSize.X))
 				} else {
 					cursor.Back(runeWidth(line[index-1]))
@@ -187,7 +187,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			if index < len(line) {
 				// move the cursor to the next line if necessary
 				if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
-					cursor.Down(1)
+					cursor.NextLine(1)
 				} else {
 					cursor.Forward(runeWidth(line[index]))
 				}
@@ -206,7 +206,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 		if r == SpecialKeyHome {
 			for index > 0 {
 				if cursorCurrent.CursorIsAtLineBegin() {
-					cursor.Up(1)
+					cursor.PreviousLine(1)
 					cursor.Forward(int(terminalSize.X))
 					cursorCurrent.X = terminalSize.X
 					cursorCurrent.Y--
@@ -222,7 +222,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 		} else if r == SpecialKeyEnd {
 			for index != len(line) {
 				if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
-					cursor.Down(1)
+					cursor.NextLine(1)
 					cursorCurrent.X = COORDINATE_SYSTEM_BEGIN
 					cursorCurrent.Y++
 
@@ -251,7 +251,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 				}
 				// erase what's left on last line
 				if cursorCurrent.Y < terminalSize.Y {
-					cursor.Down(1)
+					cursor.NextLine(1)
 					EraseLine(rr.stdio.Out, ERASE_LINE_END)
 				}
 				// restore cursor
@@ -302,7 +302,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 				// restore the position of the cursor horizontally
 				cursor.Restore()
 				// restore the position of the cursor vertically
-				cursor.Up(1)
+				cursor.PreviousLine(1)
 			} else {
 				// restore cursor
 				cursor.Restore()
@@ -310,7 +310,7 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 			// check if cursor needs to move to next line
 			cursorCurrent, _ = cursor.Location(rr.Buffer())
 			if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
-				cursor.Down(1)
+				cursor.NextLine(1)
 			} else {
 				cursor.Forward(runeWidth(r))
 			}


### PR DESCRIPTION
This PR addresses a bug reported in #307 and reverts the changes made by @System-Glitch which seems to have broken runereader in both windows and the default mac terminal.

Unfortunately this means we don't currently support Konsole but that can come after this gets fixed.

cc @pantelis-karamolegkos