### PR TITLE
Fix PreviousLine and NextLine on linux

### DIFF
--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -42,12 +42,12 @@ func (c *Cursor) Back(n int) {
 
 // NextLine moves cursor to beginning of the line n lines down.
 func (c *Cursor) NextLine(n int) {
-	fmt.Fprintf(c.Out, "\x1b[%dE", n)
+	c.Down(1)
 }
 
 // PreviousLine moves cursor to beginning of the line n lines up.
 func (c *Cursor) PreviousLine(n int) {
-	fmt.Fprintf(c.Out, "\x1b[%dF", n)
+	c.Up(1)
 }
 
 // HorizontalAbsolute moves cursor horizontally to x.


### PR DESCRIPTION
References:

#300 #302 #307 #308 

I think this change will be enough to make it work on both Windows and Linux. I have tested in cmd.exe on windows, and on Ubuntu Konsole and VSCode integrated terminal. **I cannot test on MacOS though because I don't own a Mac**.

**Logic behind this change**:

In `cursor_windows.go`, `PreviousLine()` calls `Down()` and `HorizontalAbsolute()`, so I just did the same for linux but without `HorizontalAbsolute()` because it is apparently not needed (Test it on MacOS and tell me if it works. If it doesn't, then I think adding a call to `HorizontalAbsolute()` would do the trick). This allows us to keep `PreviousLine()` and `NextLine()` and don't have a conflict in naming between the windows and other versions.