### PR TITLE
Prevent cursor from being hidden

### DIFF
--- a/input.go
+++ b/input.go
@@ -149,8 +149,7 @@ func (i *Input) Prompt(config *PromptConfig) (interface{}, error) {
 	defer rr.RestoreTermMode()
 
 	cursor := i.NewCursor()
-	cursor.Hide()       // hide the cursor
-	defer cursor.Show() // show the cursor when we're done
+	cursor.Show() // show the cursor when we're done
 
 	// start waiting for input
 	for {


### PR DESCRIPTION
The cursor was hidden during input. This allows the cursor to be displayed.