### PR TITLE
Help Text Color configurable for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ The icons and their default text and format are summarized below:
 | SelectFocus    | >    | green      | Marks the current focus in `Select` and `MultiSelect` prompts |
 | UnmarkedOption | [ ]  | default+hb | Marks an unselected option in a `MultiSelect` prompt          |
 | MarkedOption   | [x]  | cyan+b     | Marks a chosen selection in a `MultiSelect` prompt            |
+| PromptText     | []   | cyan       | Marks a chosen selection in a `MultiSelect` prompt            |
 
 ## Custom Types
 

--- a/multiline.go
+++ b/multiline.go
@@ -32,7 +32,7 @@ var MultilineQuestionTemplate = `
   {{- if .Answer }}{{ "\n" }}{{ end }}
 {{- else }}
   {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
-  {{- color "cyan"}}[Enter 2 empty lines to finish]{{color "reset"}}
+  {{- color $.Config.Icons.PromptText.Format}}[Enter 2 empty lines to finish]{{color "reset"}}
 {{- end}}`
 
 func (i *Multiline) Prompt(config *PromptConfig) (interface{}, error) {

--- a/multiselect.go
+++ b/multiselect.go
@@ -53,7 +53,7 @@ var MultiSelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
-	{{- "  "}}{{- color "cyan"}}[Use arrows to move, space to select, <right> to all, <left> to none, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
+	{{- "  "}}{{- color $.Config.Icons.PromptText.Format}}[Use arrows to move, space to select, <right> to all, <left> to none, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $option := .PageEntries}}
     {{- if eq $ix $.SelectedIndex }}{{color $.Config.Icons.SelectFocus.Format }}{{ $.Config.Icons.SelectFocus.Text }}{{color "reset"}}{{else}} {{end}}

--- a/select.go
+++ b/select.go
@@ -28,6 +28,7 @@ type Select struct {
 	VimMode       bool
 	FilterMessage string
 	Filter        func(filter string, value string, index int) bool
+	HelpTextColor string
 	filter        string
 	selectedIndex int
 	useDefault    bool
@@ -51,7 +52,7 @@ var SelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else}}
-  {{- "  "}}{{- color "cyan"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
+  {{- "  "}}{{- color .HelpTextColor}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $choice := .PageEntries}}
     {{- if eq $ix $.SelectedIndex }}{{color $.Config.Icons.SelectFocus.Format }}{{ $.Config.Icons.SelectFocus.Text }} {{else}}{{color "default"}}  {{end}}
@@ -59,6 +60,8 @@ var SelectQuestionTemplate = `
     {{- color "reset"}}{{"\n"}}
   {{- end}}
 {{- end}}`
+
+// {{- "  "}}{{- color "cyan"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
 
 // OnChange is called on every keypress.
 func (s *Select) OnChange(key rune, config *PromptConfig) bool {
@@ -202,6 +205,11 @@ func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
 	if len(s.Options) == 0 {
 		// we failed
 		return "", errors.New("please provide options to select from")
+	}
+
+	// set help text color to cyan by default if there is not user input
+	if s.HelpTextColor == "" {
+		s.HelpTextColor = "cyan"
 	}
 
 	// start off with the first option selected

--- a/select.go
+++ b/select.go
@@ -28,7 +28,6 @@ type Select struct {
 	VimMode       bool
 	FilterMessage string
 	Filter        func(filter string, value string, index int) bool
-	HelpTextColor string
 	filter        string
 	selectedIndex int
 	useDefault    bool
@@ -52,7 +51,7 @@ var SelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else}}
-  {{- "  "}}{{- color .HelpTextColor}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
+  {{- "  "}}{{- color  .Config.Icons.PromptText.Format  }}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $choice := .PageEntries}}
     {{- if eq $ix $.SelectedIndex }}{{color $.Config.Icons.SelectFocus.Format }}{{ $.Config.Icons.SelectFocus.Text }} {{else}}{{color "default"}}  {{end}}
@@ -60,8 +59,6 @@ var SelectQuestionTemplate = `
     {{- color "reset"}}{{"\n"}}
   {{- end}}
 {{- end}}`
-
-// {{- "  "}}{{- color "cyan"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
 
 // OnChange is called on every keypress.
 func (s *Select) OnChange(key rune, config *PromptConfig) bool {
@@ -205,11 +202,6 @@ func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
 	if len(s.Options) == 0 {
 		// we failed
 		return "", errors.New("please provide options to select from")
-	}
-
-	// set help text color to cyan by default if there is not user input
-	if s.HelpTextColor == "" {
-		s.HelpTextColor = "cyan"
 	}
 
 	// start off with the first option selected

--- a/survey.go
+++ b/survey.go
@@ -47,6 +47,9 @@ func defaultAskOptions() *AskOptions {
 					Text:   ">",
 					Format: "cyan+b",
 				},
+				PromptText: Icon{
+					Format: "cyan",
+				},
 			},
 			Filter: func(filter string, value string, index int) (include bool) {
 				filter = strings.ToLower(filter)
@@ -84,6 +87,7 @@ type IconSet struct {
 	MarkedOption   Icon
 	UnmarkedOption Icon
 	SelectFocus    Icon
+	PromptText     Icon
 }
 
 // Validator is a function passed to a Question after a user has provided a response.

--- a/tests/ask.go
+++ b/tests/ask.go
@@ -33,6 +33,9 @@ var singlePrompt = &survey.Input{
 
 func main() {
 
+
+
+
 	fmt.Println("Asking many.")
 	// a place to store the answers
 	ans := struct {
@@ -44,6 +47,7 @@ func main() {
 		fmt.Println(err.Error())
 		return
 	}
+
 
 	fmt.Println("Asking one.")
 	answer := ""
@@ -64,3 +68,5 @@ func main() {
 	}
 	fmt.Printf("Answered with %v.\n", vAns)
 }
+
+

--- a/tests/select.go
+++ b/tests/select.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/tests/util"
+	TestUtil "github.com/AlecAivazis/survey/v2/tests/util"
 )
 
 var answer = ""
@@ -10,8 +10,9 @@ var answer = ""
 var goodTable = []TestUtil.TestTableEntry{
 	{
 		"standard", &survey.Select{
-			Message: "Choose a color:",
-			Options: []string{"red", "blue", "green"},
+			Message:       "Choose a color:",
+			Options:       []string{"red", "blue", "green"},
+			HelpTextColor: "blue",
 		}, &answer, nil,
 	},
 	{

--- a/tests/select.go
+++ b/tests/select.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/AlecAivazis/survey/v2"
-	TestUtil "github.com/AlecAivazis/survey/v2/tests/util"
+	"github.com/AlecAivazis/survey/v2/tests/util"
 )
 
 var answer = ""
@@ -10,9 +10,8 @@ var answer = ""
 var goodTable = []TestUtil.TestTableEntry{
 	{
 		"standard", &survey.Select{
-			Message:       "Choose a color:",
-			Options:       []string{"red", "blue", "green"},
-			HelpTextColor: "blue",
+			Message: "Choose a color:",
+			Options: []string{"red", "blue", "green"},
 		}, &answer, nil,
 	},
 	{


### PR DESCRIPTION
Hi My Name is Kenny and I want to help with this project.
I added some code to make the help text color configurable with respect to #298 
the UX with the added functionality should be the same, 
as you can still have the default cyan color help text without any changes.

For now its only in select.go. If i get a nod i can also expand it to other prompts.

Thank you!