### PR TITLE
Fix re-rendering when prompt is exactly the width of the terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/AlecAivazis/survey/v2
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8
+	github.com/creack/pty v1.1.11
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,10 @@ module github.com/AlecAivazis/survey/v2
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8
-	github.com/creack/pty v1.1.11
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/kr/pty v1.1.4 // indirect
+	github.com/kr/pty v1.1.4
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.8
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
-github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
-github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDGgJGQpNflI3+MJSBhsgT5PCtzBQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDGgJGQpNflI3+MJSBhsgT5PCtzBQ=

--- a/renderer.go
+++ b/renderer.go
@@ -148,8 +148,15 @@ func (r *Renderer) countLines(buf bytes.Buffer) int {
 			delim = len(bufBytes) // no new line found, read rest of text
 		}
 
-		// account for word wrapping
-		count += int(utf8.RuneCount(bufBytes[curr:delim]) / w)
+		if lineWidth := utf8.RuneCount(bufBytes[curr:delim]); lineWidth > w {
+			// account for word wrapping
+			count += lineWidth / w
+			if (lineWidth % w) == 0 {
+				// content whose width is exactly a multiplier of available width should not
+				// count as having wrapped on the last line
+				count -= 1
+			}
+		}
 		curr = delim + 1
 	}
 

--- a/renderer_posix_test.go
+++ b/renderer_posix_test.go
@@ -1,0 +1,81 @@
+// +build !windows
+
+package survey
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	expect "github.com/Netflix/go-expect"
+	"github.com/hinshun/vt10x"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderer_countLines(t *testing.T) {
+	t.Parallel()
+
+	termWidth := 72
+	stdout := new(bytes.Buffer)
+	c, _, err := vt10x.NewVT10XConsole(expect.WithStdout(stdout))
+	vt10x.ResizePty(c.Tty(), termWidth, 30)
+	require.Nil(t, err)
+	defer c.Close()
+	defer c.Tty().Close()
+
+	r := Renderer{stdio: Stdio(c)}
+
+	tests := []struct {
+		name  string
+		buf   *bytes.Buffer
+		wants int
+	}{
+		{
+			name:  "empty",
+			buf:   new(bytes.Buffer),
+			wants: 0,
+		},
+		{
+			name:  "no newline",
+			buf:   bytes.NewBufferString("hello"),
+			wants: 0,
+		},
+		{
+			name:  "short line",
+			buf:   bytes.NewBufferString("hello\n"),
+			wants: 1,
+		},
+		{
+			name:  "three short lines",
+			buf:   bytes.NewBufferString("hello\nbeautiful\nworld\n"),
+			wants: 3,
+		},
+		{
+			name:  "full line",
+			buf:   bytes.NewBufferString(strings.Repeat("A", termWidth) + "\n"),
+			wants: 1,
+		},
+		{
+			name:  "overflow",
+			buf:   bytes.NewBufferString(strings.Repeat("A", termWidth+1) + "\n"),
+			wants: 2,
+		},
+		{
+			name:  "overflow fills 2nd line",
+			buf:   bytes.NewBufferString(strings.Repeat("A", termWidth*2) + "\n"),
+			wants: 2,
+		},
+		{
+			name:  "overflow spills to 3rd line",
+			buf:   bytes.NewBufferString(strings.Repeat("A", termWidth*2+1) + "\n"),
+			wants: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := r.countLines(*tt.buf)
+			assert.Equal(t, tt.wants, n)
+		})
+	}
+}

--- a/renderer_posix_test.go
+++ b/renderer_posix_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
-	pseudotty "github.com/creack/pty"
+	pseudotty "github.com/kr/pty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
The code that measures width of rendered lines of content and whether any have overflown in the terminal did not account for the possibility that the content could be _exactly_ the width of the terminal. In that case, it shouldn't be counted as overflow.

Fixes #318
Followup to #291, #288
