### PR TITLE
Revert "Add OnInterrupt to run function code on CTRL+C"

### DIFF
--- a/survey.go
+++ b/survey.go
@@ -10,10 +10,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 )
 
-// OnInterrupt is the function to run when
-// SIGINT (CTRL+C) is sent to the process.
-var OnInterrupt func()
-
 // DefaultAskOptions is the default options on ask, using the OS stdio.
 func defaultAskOptions() *AskOptions {
 	return &AskOptions{
@@ -60,7 +56,6 @@ func defaultAskOptions() *AskOptions {
 			},
 			KeepFilter: false,
 		},
-		OnInterrupt: OnInterrupt,
 	}
 }
 func defaultPromptConfig() *PromptConfig {
@@ -142,7 +137,6 @@ type AskOptions struct {
 	Stdio        terminal.Stdio
 	Validators   []Validator
 	PromptConfig PromptConfig
-	OnInterrupt  func()
 }
 
 // WithStdio specifies the standard input, output and error files survey
@@ -183,16 +177,6 @@ func WithValidator(v Validator) AskOpt {
 		// add the provided validator to the list
 		options.Validators = append(options.Validators, v)
 
-		// nothing went wrong
-		return nil
-	}
-}
-
-// WithInterruptFunc specifies a function to run on recieving
-// SIGINT (aka CTRL+C) during prompt.
-func WithInterruptFunc(fn func()) AskOpt {
-	return func(options *AskOptions) error {
-		options.OnInterrupt = fn
 		// nothing went wrong
 		return nil
 	}
@@ -307,10 +291,6 @@ func Ask(qs []*Question, response interface{}, opts ...AskOpt) error {
 
 		// grab the user input and save it
 		ans, err := q.Prompt.Prompt(&options.PromptConfig)
-		// if SIGINT is recieved.
-		if err == terminal.InterruptErr {
-			options.OnInterrupt()
-		}
 		// if there was a problem
 		if err != nil {
 			return err

--- a/survey_posix_test.go
+++ b/survey_posix_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func RunTest(t *testing.T, procedure func(*expect.Console), test func(terminal.Stdio) error) error {
+func RunTest(t *testing.T, procedure func(*expect.Console), test func(terminal.Stdio) error) {
 	t.Parallel()
 
 	// Multiplex output to a buffer as well for the raw bytes.
@@ -28,6 +28,7 @@ func RunTest(t *testing.T, procedure func(*expect.Console), test func(terminal.S
 	}()
 
 	err = test(Stdio(c))
+	require.Nil(t, err)
 
 	// Close the slave end of the pty, and read the remaining bytes from the master end.
 	c.Tty().Close()
@@ -37,6 +38,4 @@ func RunTest(t *testing.T, procedure func(*expect.Console), test func(terminal.S
 
 	// Dump the terminal's screen.
 	t.Logf("\n%s", expect.StripTrailingEmptyLines(state.String()))
-
-	return err
 }

--- a/survey_test.go
+++ b/survey_test.go
@@ -31,7 +31,7 @@ type PromptTest struct {
 
 func RunPromptTest(t *testing.T, test PromptTest) {
 	var answer interface{}
-	err := RunTest(t, test.procedure, func(stdio terminal.Stdio) error {
+	RunTest(t, test.procedure, func(stdio terminal.Stdio) error {
 		var err error
 		if p, ok := test.prompt.(wantsStdio); ok {
 			p.WithStdio(stdio)
@@ -40,13 +40,12 @@ func RunPromptTest(t *testing.T, test PromptTest) {
 		answer, err = test.prompt.Prompt(defaultPromptConfig())
 		return err
 	})
-	require.Nil(t, err)
 	require.Equal(t, test.expected, answer)
 }
 
 func RunPromptTestKeepFilter(t *testing.T, test PromptTest) {
 	var answer interface{}
-	err := RunTest(t, test.procedure, func(stdio terminal.Stdio) error {
+	RunTest(t, test.procedure, func(stdio terminal.Stdio) error {
 		var err error
 		if p, ok := test.prompt.(wantsStdio); ok {
 			p.WithStdio(stdio)
@@ -56,7 +55,6 @@ func RunPromptTestKeepFilter(t *testing.T, test PromptTest) {
 		answer, err = test.prompt.Prompt(config)
 		return err
 	})
-	require.Nil(t, err)
 	require.Equal(t, test.expected, answer)
 }
 
@@ -135,6 +133,7 @@ func TestPagination_lastHalf(t *testing.T) {
 
 func TestAsk(t *testing.T) {
 	t.Skip()
+	return
 	tests := []struct {
 		name      string
 		questions []*Question
@@ -251,10 +250,10 @@ func TestAsk(t *testing.T) {
 				"pizza":                    true,
 				"commit-message":           "Add editor prompt tests\n",
 				"commit-message-validated": "Add editor prompt tests\n",
-				"name":                     "Johnny Appleseed",
-				"day":                      []string{"Monday", "Wednesday"},
-				"password":                 "secret",
-				"color":                    "yellow",
+				"name":     "Johnny Appleseed",
+				"day":      []string{"Monday", "Wednesday"},
+				"password": "secret",
+				"color":    "yellow",
 			},
 		},
 		{
@@ -306,10 +305,9 @@ func TestAsk(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			answers := make(map[string]interface{})
-			err := RunTest(t, test.procedure, func(stdio terminal.Stdio) error {
+			RunTest(t, test.procedure, func(stdio terminal.Stdio) error {
 				return Ask(test.questions, &answers, WithStdio(stdio.In, stdio.Out, stdio.Err))
 			})
-			require.Nil(t, err)
 			require.Equal(t, test.expected, answers)
 		})
 	}
@@ -324,58 +322,4 @@ func TestAsk_returnsErrorIfTargetIsNil(t *testing.T) {
 		// the test failed
 		t.Error("Did not encounter error when asking with no where to record.")
 	}
-}
-
-func TestOnInterruptFunc(t *testing.T) {
-	// No Interrupt function set.
-	t.Run("No OnInterrupt", func(t *testing.T) {
-		answer := ""
-		err := RunTest(t, func(e *expect.Console) {
-			e.ExpectString("Are you a bot?")
-			e.SendLine(string(terminal.KeyInterrupt))
-			e.ExpectEOF()
-		}, func(t terminal.Stdio) error {
-			return AskOne(&Input{Message: "Are you a bot?"}, &answer,
-				WithStdio(t.In, t.Out, t.Err))
-		})
-
-		require.Equal(t, terminal.InterruptErr, err)
-		require.Equal(t, "", answer)
-	})
-
-	// Set global Interrupt function.
-	OnInterrupt = func() { fmt.Println("Ended abruptly!") }
-	t.Run("Global OnInterrupt", func(t *testing.T) {
-		answer := ""
-		err := RunTest(t, func(e *expect.Console) {
-			e.ExpectString("Are you a bot?")
-			e.SendLine(string(terminal.KeyInterrupt))
-			e.ExpectString("Ended abruptly!")
-			e.ExpectEOF()
-		}, func(t terminal.Stdio) error {
-			return AskOne(&Input{Message: "Are you a bot?"}, &answer,
-				WithStdio(t.In, t.Out, t.Err))
-		})
-
-		require.Equal(t, terminal.InterruptErr, err)
-		require.Equal(t, "", answer)
-	})
-
-	// Set local Interrupt function (overide global).
-	t.Run("Local Interrupt (override global", func(t *testing.T) {
-		answer := ""
-		err := RunTest(t, func(e *expect.Console) {
-			e.ExpectString("Are you a bot?")
-			e.SendLine(string(terminal.KeyInterrupt))
-			e.ExpectString("The end.")
-			e.ExpectEOF()
-		}, func(t terminal.Stdio) error {
-			return AskOne(&Input{Message: "Are you a bot?"}, &answer,
-				WithStdio(t.In, t.Out, t.Err),
-				WithInterruptFunc(func() { fmt.Println("The end.") }))
-		})
-
-		require.Equal(t, terminal.InterruptErr, err)
-		require.Equal(t, "", answer)
-	})
 }

--- a/survey_windows_test.go
+++ b/survey_windows_test.go
@@ -7,7 +7,6 @@ import (
 	expect "github.com/Netflix/go-expect"
 )
 
-func RunTest(t *testing.T, procedure func(*expect.Console), test func(terminal.Stdio) error) error {
+func RunTest(t *testing.T, procedure func(*expect.Console), test func(terminal.Stdio) error) {
 	t.Skip("Windows does not support psuedoterminals")
-	return nil
 }


### PR DESCRIPTION
@mislav @infinitepr0 - I'm going to revert #301 and republish on the `v2.2.x` line.

Also, before we merge it back in - @infinitepr0 is there an issue with just relying on the return value from `Ask` or `AskOne` in order to capture an interrupt? 