### PR TITLE
Use rune when delete or filter answer

### DIFF
--- a/input.go
+++ b/input.go
@@ -105,7 +105,8 @@ func (i *Input) OnChange(key rune, config *PromptConfig) (bool, error) {
 		}
 	} else if key == terminal.KeyDelete || key == terminal.KeyBackspace {
 		if i.answer != "" {
-			i.answer = i.answer[0 : len(i.answer)-1]
+			runeAnswer := []rune(i.answer)
+			i.answer = string(runeAnswer[0 : len(runeAnswer)-1])
 		}
 	} else if key >= terminal.KeySpace {
 		i.answer += string(key)

--- a/input_test.go
+++ b/input_test.go
@@ -210,6 +210,34 @@ func TestInputPrompt(t *testing.T) {
 			"R",
 		},
 		{
+			"Test Input prompt interaction when delete",
+			&Input{
+				Message: "What is your name?",
+			},
+			func(c *expect.Console) {
+				c.ExpectString("What is your name?")
+				c.Send("Johnny ")
+				c.Send(string(terminal.KeyDelete))
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			"Johnny",
+		},
+		{
+			"Test Input prompt interaction when delete rune",
+			&Input{
+				Message: "What is your name?",
+			},
+			func(c *expect.Console) {
+				c.ExpectString("What is your name?")
+				c.Send("小明")
+				c.Send(string(terminal.KeyDelete))
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			"小",
+		},
+		{
 			"Test Input prompt interaction when ask for suggestion with empty value",
 			&Input{
 				Message: "What is your favorite month?",

--- a/multiselect.go
+++ b/multiselect.go
@@ -113,7 +113,8 @@ func (m *MultiSelect) OnChange(key rune, config *PromptConfig) {
 		m.filter = ""
 	} else if key == terminal.KeyDelete || key == terminal.KeyBackspace {
 		if m.filter != "" {
-			m.filter = m.filter[0 : len(m.filter)-1]
+			runeFilter := []rune(m.filter)
+			m.filter = string(runeFilter[0 : len(runeFilter)-1])
 		}
 	} else if key >= terminal.KeySpace {
 		m.filter += string(key)

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -488,6 +488,53 @@ func TestMultiSelectPrompt(t *testing.T) {
 				core.OptionAnswer{Value: "Saturday", Index: 6},
 			},
 		},
+		{
+			"delete filter word",
+			&MultiSelect{
+				Message: "What days do you prefer:",
+				Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
+			},
+			func(c *expect.Console) {
+				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]")
+				// Filter down to 'Sunday'
+				c.Send("su")
+				// Delete 'u'
+				c.Send(string(terminal.KeyDelete))
+				// Filter down to 'Saturday'
+				c.Send("at")
+				// Select 'Saturday'
+				c.Send(string(terminal.KeyArrowDown))
+				c.Send(" ")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			[]core.OptionAnswer{
+				core.OptionAnswer{Value: "Saturday", Index: 6},
+			},
+		},
+		{
+			"delete filter word in rune",
+			&MultiSelect{
+				Message: "今天中午吃什么？",
+				Options: []string{"青椒牛肉丝", "小炒肉", "小煎鸡"},
+			},
+			func(c *expect.Console) {
+				c.ExpectString("今天中午吃什么？  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]")
+				// Filter down to 小炒肉.
+				c.Send("小炒")
+				// Filter down to 小炒肉 and 小煎鸡.
+				c.Send(string(terminal.KeyDelete))
+				// Filter down to 小煎鸡.
+				c.Send("煎")
+				// Select 小煎鸡.
+				c.Send(" ")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			[]core.OptionAnswer{
+				core.OptionAnswer{Value: "小煎鸡", Index: 2},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/select.go
+++ b/select.go
@@ -114,8 +114,9 @@ func (s *Select) OnChange(key rune, config *PromptConfig) bool {
 	} else if key == terminal.KeyDelete || key == terminal.KeyBackspace {
 		// if there is content in the filter to delete
 		if s.filter != "" {
+			runeFilter := []rune(s.filter)
 			// subtract a line from the current filter
-			s.filter = s.filter[0 : len(s.filter)-1]
+			s.filter = string(runeFilter[0 : len(runeFilter)-1])
 			// we removed the last value in the filter
 		}
 	} else if key >= terminal.KeySpace {

--- a/select_test.go
+++ b/select_test.go
@@ -327,6 +327,42 @@ func TestSelectPrompt(t *testing.T) {
 			},
 			core.OptionAnswer{Index: 0, Value: "red"},
 		},
+		{
+			"delete filter word",
+			&Select{
+				Message: "Choose a color:",
+				Options: []string{"red", "blue", "black"},
+			},
+			func(c *expect.Console) {
+				c.ExpectString("Choose a color:")
+				// Filter down to blue.
+				c.Send("blu")
+				// Filter down to blue and black.
+				c.Send(string(terminal.KeyDelete))
+				// Select black.
+				c.SendLine(string(terminal.KeyArrowDown))
+				c.ExpectEOF()
+			},
+			core.OptionAnswer{Index: 2, Value: "black"},
+		},
+		{
+			"delete filter word in rune",
+			&Select{
+				Message: "今天中午吃什么？",
+				Options: []string{"青椒牛肉丝", "小炒肉", "小煎鸡"},
+			},
+			func(c *expect.Console) {
+				c.ExpectString("今天中午吃什么？")
+				// Filter down to 小炒肉.
+				c.Send("小炒")
+				// Filter down to 小炒肉 and 小煎鸡.
+				c.Send(string(terminal.KeyDelete))
+				// Select 小煎鸡.
+				c.SendLine(string(terminal.KeyArrowDown))
+				c.ExpectEOF()
+			},
+			core.OptionAnswer{Index: 2, Value: "小煎鸡"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When using Unicode in the `string` type answer will cause a problem.

Example:

```bash
> go run examples/simple.go
? What is your name? 小明
```