### PR TITLE
Fixes #334: Make sure the cursor goes back to the begining of the lin…

### DIFF
--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -43,11 +43,13 @@ func (c *Cursor) Back(n int) {
 // NextLine moves cursor to beginning of the line n lines down.
 func (c *Cursor) NextLine(n int) {
 	c.Down(1)
+	c.HorizontalAbsolute(0)
 }
 
 // PreviousLine moves cursor to beginning of the line n lines up.
 func (c *Cursor) PreviousLine(n int) {
 	c.Up(1)
+	c.HorizontalAbsolute(0)
 }
 
 // HorizontalAbsolute moves cursor horizontally to x.


### PR DESCRIPTION
…e when jumping lines.

See #334 for the details. This code is doing the same as what Windows does.

There is something odd in the the n parameter passed to both methods is never used as we use 1. The Windows code does not do this and the previous code (changed in #309) did not do this either. I have a feeling it should be `c.Down(n)` and `c.Up(n)` but I did not analyze this library enough to be confident.