### PR TITLE
restore cursor on error

### DIFF
--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -167,8 +167,11 @@ func (c *Cursor) Size(buf *bytes.Buffer) (*Coord, error) {
 
 	// hide the cursor (so it doesn't blink when getting the size of the terminal)
 	c.Hide()
+	defer c.Show()
+
 	// save the current location of the cursor
 	c.Save()
+	defer c.Restore()
 
 	// move the cursor to the very bottom of the terminal
 	c.Move(999, 999)
@@ -179,11 +182,6 @@ func (c *Cursor) Size(buf *bytes.Buffer) (*Coord, error) {
 		return nil, err
 	}
 
-	// move back where we began
-	c.Restore()
-
-	// show the cursor
-	c.Show()
 	// since the bottom was calculated in the lower right corner, it
 	// is the dimensions we are looking for
 	return bottom, nil


### PR DESCRIPTION
This fixes restoring the state of the cursor when an error occurs when detecting terminal size.
fixes #282 

Piped stdin is still not handled correctly:
The problem here is, that with piped stdin, `Cursor.Location()` fails with `io.EOF`:
https://github.com/AlecAivazis/survey/blob/f45c05b5039ca1f9c9c562be232f1c4044e0add0/terminal/cursor.go#L106-L109
Subsequently, no input is read, and control commands printed instead of being applied.

I'm not exactly sure how a piped stdin differs from a terminal stdin, so I don't know how to fix this.
One step surely would be to change `Cursor`, so that it detects piped stdin, and switches to a NO-OP mode?

If this can't be fixed properly, the README should clearly state that using survey with piped stdin breaks the application.