### PR TITLE
Add optional headers to Select

### DIFF
--- a/select.go
+++ b/select.go
@@ -21,6 +21,7 @@ for them to select using the arrow keys and enter. Response type is a string.
 type Select struct {
 	Renderer
 	Message       string
+	Headers       []string
 	Options       []string
 	Default       interface{}
 	Help          string
@@ -53,6 +54,9 @@ var SelectQuestionTemplate = `
 {{- else}}
   {{- "  "}}{{- color "cyan"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
+  {{- range $l := .Headers }}
+  {{- "  "}}{{- $l -}}{{ "\n"}}
+  {{- end }}
   {{- range $ix, $choice := .PageEntries}}
     {{- if eq $ix $.SelectedIndex }}{{color $.Config.Icons.SelectFocus.Format }}{{ $.Config.Icons.SelectFocus.Text }} {{else}}{{color "default"}}  {{end}}
     {{- $choice.Value}}


### PR DESCRIPTION
This small addition to the template helps to create a simple selection with a table view.

If you consider this as useful addition I can add tests and examples as well.

Example usage:

```go
import "github.com/olekukonko/tablewriter"

headers, choices := buildTableSelect(data, []string{"A", "B", "C"})
err = survey.AskOne(&survey.Select{
        message: "Select an option",
        Options: choices,
        Headers: headers,},
    &indexChoice)

func buildTableSelect(data [][]string, columns []string) (headers []string, choices []string) {
	tableString := &strings.Builder{}
	table := tablewriter.NewWriter(tableString)
	table.SetBorder(false)
	table.SetCenterSeparator("")
	table.SetColumnSeparator("")
	table.SetRowSeparator("")
	table.SetHeaderLine(false)
	table.SetHeader(columns)
	table.AppendBulk(data)
	table.Render()
	// Split rendered table into lines
	lines := strings.Split(tableString.String(), "\n")
	// Get the headers
	headers = lines[:1]
	// Chomp headers and tailing newline
	choices = lines[1 : len(lines)-1]
	return headers, choices
}
```