### PR TITLE
Re-enable TestAsk

### DIFF
--- a/survey_test.go
+++ b/survey_test.go
@@ -150,12 +150,14 @@ func TestAsk(t *testing.T) {
 				{
 					Name: "commit-message",
 					Prompt: &Editor{
+						Editor:  "vi",
 						Message: "Edit git commit message",
 					},
 				},
 				{
 					Name: "commit-message-validated",
 					Prompt: &Editor{
+						Editor:  "vi",
 						Message: "Edit git commit message",
 					},
 					Validate: func(v interface{}) error {

--- a/survey_test.go
+++ b/survey_test.go
@@ -132,8 +132,6 @@ func TestPagination_lastHalf(t *testing.T) {
 }
 
 func TestAsk(t *testing.T) {
-	t.Skip()
-	return
 	tests := []struct {
 		name      string
 		questions []*Question
@@ -174,6 +172,7 @@ func TestAsk(t *testing.T) {
 						Message: "What is your name?",
 					},
 				},
+				/* TODO gets stuck
 				{
 					Name: "day",
 					Prompt: &MultiSelect{
@@ -181,6 +180,7 @@ func TestAsk(t *testing.T) {
 						Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
 					},
 				},
+				*/
 				{
 					Name: "password",
 					Prompt: &Password{
@@ -226,6 +226,7 @@ func TestAsk(t *testing.T) {
 				c.ExpectString("What is your name?")
 				c.SendLine("Johnny Appleseed")
 
+				/* TODO gets stuck
 				// MultiSelect
 				c.ExpectString("What days do you prefer:  [Use arrows to move, space to select, type to filter]")
 				// Select Monday.
@@ -235,6 +236,7 @@ func TestAsk(t *testing.T) {
 				c.Send(string(terminal.KeyArrowDown))
 				c.Send(string(terminal.KeyArrowDown))
 				c.SendLine(" ")
+				*/
 
 				// Password
 				c.ExpectString("Please type your password")
@@ -250,10 +252,12 @@ func TestAsk(t *testing.T) {
 				"pizza":                    true,
 				"commit-message":           "Add editor prompt tests\n",
 				"commit-message-validated": "Add editor prompt tests\n",
-				"name":     "Johnny Appleseed",
-				"day":      []string{"Monday", "Wednesday"},
+				"name":                     "Johnny Appleseed",
+				/* TODO
+				"day":                      []string{"Monday", "Wednesday"},
+				*/
 				"password": "secret",
-				"color":    "yellow",
+				"color":    core.OptionAnswer{Index: 3, Value: "yellow"},
 			},
 		},
 		{
@@ -271,6 +275,7 @@ func TestAsk(t *testing.T) {
 				c.ExpectString("What is your name?")
 				c.SendLine("")
 				c.ExpectString("Sorry, your reply was invalid: Value is required")
+				time.Sleep(time.Millisecond)
 				c.SendLine("Johnny Appleseed")
 				c.ExpectEOF()
 			},


### PR DESCRIPTION
Those got disabled in https://github.com/AlecAivazis/survey/pull/216/files#diff-3a029c8ea50304c9dc5637560df2375bc28f1620d72744a13f4d3c152bb16a4aR120 and apparently were forgotten since then?

I noticed several tests, some here and some in other files, _sometimes_ get stuck when running `go test -v`.  
Everything works reliably without `-v`, so I guess there are timing issues due to verbose printing; but when focusing on a single test with `-run=REGEXP` they also work pretty reliably even with `-v`.

- Exception: I kept the "What days do you prefer" test commented out because it always gets stuck, with or without `-v`, and I don't know how to debug it (`-v` doesn't help — it doesn't get to show "raw output" which is usually very helpful).
