### PR TITLE
fix: smkx keypad-transmit mode

### DIFF
--- a/terminal/runereader_posix.go
+++ b/terminal/runereader_posix.go
@@ -1,4 +1,3 @@
-//go:build !windows
 // +build !windows
 
 // The terminal mode manipulation code is derived heavily from:

--- a/terminal/runereader_posix.go
+++ b/terminal/runereader_posix.go
@@ -77,7 +77,7 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 			return r, size, err
 		}
 		if r != '[' && r != 'O' {
-			return r, size, fmt.Errorf("unexpected Escape Sequence: %q", []rune{'\033', r})
+			return r, size, fmt.Errorf("Unexpected Escape Sequence: %q", []rune{'\033', r})
 		}
 		r, size, err = rr.state.reader.ReadRune()
 		if err != nil {
@@ -105,7 +105,6 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 			rr.state.reader.Discard(1)
 			return IgnoreKey, 1, nil
 		}
-		return r, size, fmt.Errorf("unknown Escape Sequence: %q", []rune{'\033', '[', r})
 	}
 	return r, size, err
 }

--- a/terminal/runereader_posix.go
+++ b/terminal/runereader_posix.go
@@ -76,8 +76,8 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 		if err != nil {
 			return r, size, err
 		}
-		if r != '[' {
-			return r, size, fmt.Errorf("Unexpected Escape Sequence: %q", []rune{'\033', r})
+		if r != '[' && r != 'O' {
+			return r, size, fmt.Errorf("unexpected Escape Sequence: %q", []rune{'\033', r})
 		}
 		r, size, err = rr.state.reader.ReadRune()
 		if err != nil {
@@ -105,7 +105,7 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 			rr.state.reader.Discard(1)
 			return IgnoreKey, 1, nil
 		}
-		return r, size, fmt.Errorf("Unknown Escape Sequence: %q", []rune{'\033', '[', r})
+		return r, size, fmt.Errorf("unknown Escape Sequence: %q", []rune{'\033', '[', r})
 	}
 	return r, size, err
 }

--- a/terminal/runereader_posix.go
+++ b/terminal/runereader_posix.go
@@ -65,6 +65,8 @@ func (rr *RuneReader) RestoreTermMode() error {
 	return nil
 }
 
+// ReadRune Parse escape sequences such as ESC [ A for arrow keys.
+// See https://vt100.net/docs/vt102-ug/appendixc.html
 func (rr *RuneReader) ReadRune() (rune, int, error) {
 	r, size, err := rr.state.reader.ReadRune()
 	if err != nil {
@@ -74,9 +76,6 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 	if r != KeyEscape {
 		return r, size, err
 	}
-
-	// Parse escape sequences such as ESC [ A for arrow keys.
-	// See https://vt100.net/docs/vt102-ug/appendixc.html
 
 	if rr.state.reader.Buffered() == 0 {
 		// no more characters so must be `Esc` key

--- a/terminal/runereader_posix.go
+++ b/terminal/runereader_posix.go
@@ -71,7 +71,7 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 		return r, size, err
 	}
 
-	if r != '\033' {
+	if r != KeyEscape {
 		return r, size, err
 	}
 
@@ -90,7 +90,7 @@ func (rr *RuneReader) ReadRune() (rune, int, error) {
 
 	// ESC O ... or ESC [ ...?
 	if r != normalKeypad && r != applicationKeypad {
-		return r, size, fmt.Errorf("unexpected escape sequence from terminal: %q", []rune{'\033', r})
+		return r, size, fmt.Errorf("unexpected escape sequence from terminal: %q", []rune{KeyEscape, r})
 	}
 
 	keypad := r


### PR DESCRIPTION
> To see the difference between normal/application modes, consider this example:
>
> - In normal (non-application) mode, the terminal transmits a down-arrow as \E[C, which happens to echo as a down-arrow.
> - In application mode the terminal transmits \EOC, which echoes as C. That is because the \EO is the SS3 control, which says to use the character from the G3 character set for the next cell.

https://invisible-island.net/xterm/xterm.faq.html#xterm_arrows

> ESC =     Application Keypad (DECKPAM).
>
> ESC >     Normal Keypad (DECKPNM), VT100.

https://invisible-island.net/xterm/ctlseqs/ctlseqs.html

See https://vt100.net/docs/vt102-ug/appendixc.html

Fix #228
Fix #341