### PR TITLE
fix cursor updating in windows

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -72,7 +72,7 @@ func (r *Renderer) Error(config *PromptConfig, invalid error) error {
 func (r *Renderer) OffsetCursor(offset int) {
 	cursor := r.NewCursor()
 	for offset > 0 {
-		cursor.PreviousLine(-1)
+		cursor.PreviousLine(1)
 		offset--
 	}
 }


### PR DESCRIPTION
tl;dr cursor was not updating in windows; this fixes it (tested with NVDA)

long version: i noticed that the argument to `PreviousLine` was unused; I mindlessly made it `-1` as a mental TODO to investigate why it took a parameter at all. I realized that the parameter _was_ used in the windows version of the cursor code, but apparently didn't go back and fix the argument (I totally thought I had and I'm not sure what happened since I did do windows QA at some point and it worked).


