### PR TITLE
fix: error message for MinItems validator

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -87,7 +87,7 @@ func MinItems(numberItems int) Validator {
 			// if the list is shorter than the given value
 			if len(list) < numberItems {
 				// yell loudly
-				return fmt.Errorf("value is too long. Min items is %v", numberItems)
+				return fmt.Errorf("value is too short. Min items is %v", numberItems)
 			}
 		} else {
 			// otherwise we cannot convert the value into a list of answer and cannot enforce length


### PR DESCRIPTION
Currently when using `survey.MinItems(1)` with no items selected it says:
```
X Sorry, your reply was invalid: value is too long. Min items is 1
```
However it should be `too short` not `too long`