### PR TITLE
Fix Survey output on Windows

### DIFF
--- a/terminal/output_windows.go
+++ b/terminal/output_windows.go
@@ -71,6 +71,9 @@ func (w *Writer) Write(data []byte) (n int, err error) {
 		var size int
 		ch, size, err = r.ReadRune()
 		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
 			return
 		}
 		n += size


### PR DESCRIPTION
Fixes Survey on Windows.

When I was tightening out error handling in https://github.com/AlecAivazis/survey/pull/404, it didn't occur to me that some errors _want_ to be ignored.