### PR TITLE
Add `terminal.Cursor` error handling on Windows

### DIFF
--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package terminal
@@ -78,8 +79,8 @@ func (c *Cursor) Hide() error {
 	return err
 }
 
-// Move moves the cursor to a specific x,y location.
-func (c *Cursor) Move(x int, y int) error {
+// move moves the cursor to a specific x,y location.
+func (c *Cursor) move(x int, y int) error {
 	_, err := fmt.Fprintf(c.Out, "\x1b[%d;%df", x, y)
 	return err
 }
@@ -194,7 +195,7 @@ func (c *Cursor) Size(buf *bytes.Buffer) (*Coord, error) {
 	defer c.Restore()
 
 	// move the cursor to the very bottom of the terminal
-	c.Move(999, 999)
+	c.move(999, 999)
 
 	// ask for the current location
 	bottom, err := c.Location(buf)

--- a/terminal/output_windows.go
+++ b/terminal/output_windows.go
@@ -12,18 +12,6 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-var (
-	cursorFunctions = map[rune]func(c *Cursor) func(int){
-		'A': func(c *Cursor) func(int) { return c.Up },
-		'B': func(c *Cursor) func(int) { return c.Down },
-		'C': func(c *Cursor) func(int) { return c.Forward },
-		'D': func(c *Cursor) func(int) { return c.Back },
-		'E': func(c *Cursor) func(int) { return c.NextLine },
-		'F': func(c *Cursor) func(int) { return c.PreviousLine },
-		'G': func(c *Cursor) func(int) { return c.HorizontalAbsolute },
-	}
-)
-
 const (
 	foregroundBlue      = 0x1
 	foregroundGreen     = 0x2
@@ -98,9 +86,14 @@ func (w *Writer) handleEscape(r *bytes.Reader) (n int, err error) {
 	buf := make([]byte, 0, 10)
 	buf = append(buf, "\x1b"...)
 
+	var ch rune
+	var size int
 	// Check '[' continues after \x1b
-	ch, size, err := r.ReadRune()
+	ch, size, err = r.ReadRune()
 	if err != nil {
+		if err == io.EOF {
+			err = nil
+		}
 		fmt.Fprint(w.out, string(buf))
 		return
 	}
@@ -116,6 +109,9 @@ func (w *Writer) handleEscape(r *bytes.Reader) (n int, err error) {
 	for {
 		ch, size, err = r.ReadRune()
 		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
 			fmt.Fprint(w.out, string(buf))
 			return
 		}
@@ -127,47 +123,62 @@ func (w *Writer) handleEscape(r *bytes.Reader) (n int, err error) {
 		argBuf = append(argBuf, string(ch)...)
 	}
 
-	w.applyEscapeCode(buf, string(argBuf), code)
+	err = w.applyEscapeCode(buf, string(argBuf), code)
 	return
 }
 
-func (w *Writer) applyEscapeCode(buf []byte, arg string, code rune) {
+func (w *Writer) applyEscapeCode(buf []byte, arg string, code rune) error {
 	c := &Cursor{Out: w.out}
 
 	switch arg + string(code) {
 	case "?25h":
-		c.Show()
-		return
+		return c.Show()
 	case "?25l":
-		c.Hide()
-		return
+		return c.Hide()
 	}
 
-	if f, ok := cursorFunctions[code]; ok {
+	if code >= 'A' && code <= 'G' {
 		if n, err := strconv.Atoi(arg); err == nil {
-			f(c)(n)
-			return
+			switch code {
+			case 'A':
+				return c.Up(n)
+			case 'B':
+				return c.Down(n)
+			case 'C':
+				return c.Forward(n)
+			case 'D':
+				return c.Back(n)
+			case 'E':
+				return c.NextLine(n)
+			case 'F':
+				return c.PreviousLine(n)
+			case 'G':
+				return c.HorizontalAbsolute(n)
+			}
 		}
 	}
 
 	switch code {
 	case 'm':
-		w.applySelectGraphicRendition(arg)
+		return w.applySelectGraphicRendition(arg)
 	default:
 		buf = append(buf, string(code)...)
-		fmt.Fprint(w.out, string(buf))
+		_, err := fmt.Fprint(w.out, string(buf))
+		return err
 	}
 }
 
 // Original implementation: https://github.com/mattn/go-colorable
-func (w *Writer) applySelectGraphicRendition(arg string) {
+func (w *Writer) applySelectGraphicRendition(arg string) error {
 	if arg == "" {
-		procSetConsoleTextAttribute.Call(uintptr(w.handle), uintptr(w.orgAttr))
-		return
+		_, _, err := procSetConsoleTextAttribute.Call(uintptr(w.handle), uintptr(w.orgAttr))
+		return normalizeError(err)
 	}
 
 	var csbi consoleScreenBufferInfo
-	procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
+	if _, _, err := procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi))); normalizeError(err) != nil {
+		return err
+	}
 	attr := csbi.attributes
 
 	for _, param := range strings.Split(arg, ";") {
@@ -230,5 +241,13 @@ func (w *Writer) applySelectGraphicRendition(arg string) {
 		}
 	}
 
-	procSetConsoleTextAttribute.Call(uintptr(w.handle), uintptr(attr))
+	_, _, err := procSetConsoleTextAttribute.Call(uintptr(w.handle), uintptr(attr))
+	return normalizeError(err)
+}
+
+func normalizeError(err error) error {
+	if syserr, ok := err.(syscall.Errno); ok && syserr == 0 {
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
Followup to #404, which did the same for non-Windows implementations

This also un-exports `Cursor.Move()` from other implementations because it has no equivalent on Windows and thus is unsafe to use in a cross-platform manner.