### PR TITLE
Ensure accurate selected index returned from Select

### DIFF
--- a/select.go
+++ b/select.go
@@ -2,6 +2,7 @@ package survey
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -30,7 +31,6 @@ type Select struct {
 	Filter        func(filter string, value string, index int) bool
 	filter        string
 	selectedIndex int
-	useDefault    bool
 	showingHelp   bool
 }
 
@@ -94,8 +94,6 @@ func (s *Select) OnChange(key rune, config *PromptConfig) bool {
 
 		// if the user pressed the up arrow or 'k' to emulate vim
 	} else if (key == terminal.KeyArrowUp || (s.VimMode && key == 'k')) && len(options) > 0 {
-		s.useDefault = false
-
 		// if we are at the top of the list
 		if s.selectedIndex == 0 {
 			// start from the button
@@ -107,7 +105,6 @@ func (s *Select) OnChange(key rune, config *PromptConfig) bool {
 
 		// if the user pressed down or 'j' to emulate vim
 	} else if (key == terminal.KeyTab || key == terminal.KeyArrowDown || (s.VimMode && key == 'j')) && len(options) > 0 {
-		s.useDefault = false
 		// if we are at the bottom of the list
 		if s.selectedIndex == len(options)-1 {
 			// start from the top
@@ -138,8 +135,6 @@ func (s *Select) OnChange(key rune, config *PromptConfig) bool {
 		s.filter += string(key)
 		// make sure vim mode is disabled
 		s.VimMode = false
-		// make sure that we use the current value in the filtered list
-		s.useDefault = false
 	}
 
 	s.FilterMessage = ""
@@ -197,7 +192,6 @@ func (s *Select) filterOptions(config *PromptConfig) []core.OptionAnswer {
 		filter = config.Filter
 	}
 
-	//
 	for i, opt := range s.Options {
 		// i the filter says to include the option
 		if filter(s.filter, opt, i) {
@@ -219,23 +213,29 @@ func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
 		return "", errors.New("please provide options to select from")
 	}
 
-	// start off with the first option selected
-	sel := 0
-	// if there is a default
-	if s.Default != "" {
-		// find the choice
-		for i, opt := range s.Options {
-			// if the option corresponds to the default
-			if opt == s.Default {
-				// we found our initial value
-				sel = i
-				// stop looking
-				break
+	s.selectedIndex = 0
+	if s.Default != nil {
+		switch defaultValue := s.Default.(type) {
+		case string:
+			var found bool
+			for i, opt := range s.Options {
+				if opt == defaultValue {
+					s.selectedIndex = i
+					found = true
+				}
 			}
+			if !found {
+				return "", fmt.Errorf("default value %q not found in options", defaultValue)
+			}
+		case int:
+			if defaultValue >= len(s.Options) {
+				return "", fmt.Errorf("default index %d exceeds the number of options", defaultValue)
+			}
+			s.selectedIndex = defaultValue
+		default:
+			return "", errors.New("default value of select must be an int or string")
 		}
 	}
-	// save the selected index
-	s.selectedIndex = sel
 
 	// figure out the page size
 	pageSize := s.PageSize
@@ -246,7 +246,7 @@ func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
 	}
 
 	// figure out the options and index to render
-	opts, idx := paginate(pageSize, core.OptionAnswerList(s.Options), sel)
+	opts, idx := paginate(pageSize, core.OptionAnswerList(s.Options), s.selectedIndex)
 
 	cursor := s.NewCursor()
 	cursor.Save()          // for proper cursor placement during selection
@@ -267,9 +267,6 @@ func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
 	if err != nil {
 		return "", err
 	}
-
-	// by default, use the default value
-	s.useDefault = true
 
 	rr := s.NewRuneReader()
 	_ = rr.SetTermMode()
@@ -293,45 +290,16 @@ func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
 			break
 		}
 	}
+
 	options := s.filterOptions(config)
 	s.filter = ""
 	s.FilterMessage = ""
 
-	// the index to report
-	var val string
-	// if we are supposed to use the default value
-	if s.useDefault || s.selectedIndex >= len(options) {
-		// if there is a default value
-		if s.Default != nil {
-			// if the default is a string
-			if defaultString, ok := s.Default.(string); ok {
-				// use the default value
-				val = defaultString
-				// the default value could also be an interpret which is interpretted as the index
-			} else if defaultIndex, ok := s.Default.(int); ok {
-				val = s.Options[defaultIndex]
-			} else {
-				return val, errors.New("default value of select must be an int or string")
-			}
-		} else if len(options) > 0 {
-			// there is no default value so use the first
-			val = options[0].Value
-		}
-		// otherwise the selected index points to the value
-	} else if s.selectedIndex < len(options) {
-		// the
-		val = options[s.selectedIndex].Value
+	if s.selectedIndex < len(options) {
+		return options[s.selectedIndex], err
 	}
 
-	// now that we have the value lets go hunt down the right index to return
-	idx = -1
-	for i, optionValue := range s.Options {
-		if optionValue == val {
-			idx = i
-		}
-	}
-
-	return core.OptionAnswer{Value: val, Index: idx}, err
+	return options[0], err
 }
 
 func (s *Select) Cleanup(config *PromptConfig, val interface{}) error {


### PR DESCRIPTION
Fixes https://github.com/AlecAivazis/survey/issues/412 which describes the case where the selected index would be mis-reported when some options happen to share identical value. Since the Select component internally tracks the `selectedIndex`, just use that value instead of trying to determine it by comparing strings.

@AlecAivazis In my attempts to clean up default value handling here, I fear I have introduced backwards-incompatible changes. I could restore the previous behavior, sure, but I wanted to ask if it's also worth "fixing" the default value handling. Namely:

- Before, when a string value was passed, for example `Default: "moo"`, this default was used in the result when the user immediately pressed <kbd>Enter</kbd> (i.e. without otherwise interacting with the Select component) **even if the value `moo` did not exist among Options**. Now, **the prompt will error out** noting that the default value must be present among Options, mainly so that it can be visually pre-selected when rendering the widget.

- Before, when an invalid int value was passed, for example `Default: 1000` when there are fewer than 1000 Options, a panic would happen when the user immediately pressed <kbd>Enter</kbd>, _but not otherwise_. Now, the prompt will **immediately error out** noting that the Default value is invalid since it's out of bounds.

So, what I changed here felt like fixing bugs to me, but I can imagine that some users might be relying on these features, for example having a Default that's not among Options so they can detect when the user wanted to skip a Select. I'm not sure if those features were worth keeping, though. For example, consider this prompt:

```
? Choose a country:  [Use arrows to move, type to filter]
> Afghanistan
  Åland Islands
  Albania
```

If I press <kbd>Enter</kbd> here, I would expect that "Afghanistan" got selected. However, if there was a Default value such as "moo", that string will be used instead of "Afghanistan", which I find counter-intuitive. I would rather break this feature than have users rely on it.

What are your thoughts?