### PR TITLE
Allow editable default for Input prompt

### DIFF
--- a/examples/cursor.go
+++ b/examples/cursor.go
@@ -12,8 +12,8 @@ var simpleQs = []*survey.Question{
 		Name: "name",
 		Prompt: &survey.Input{
 			Message: "What is your name?",
+			Default: "Jordan",
 		},
-		Validate: survey.Required,
 	},
 }
 
@@ -28,5 +28,5 @@ func main() {
 		return
 	}
 	// print the answers
-	fmt.Printf("Your name is %s.\n", ansmap["name"])
+	fmt.Printf("Your name is %q.\n", ansmap["name"])
 }

--- a/input.go
+++ b/input.go
@@ -59,7 +59,6 @@ var InputQuestionTemplate = `
     {{- if and .Help (not .ShowHelp)}}{{ print .Config.HelpInput }} for help {{- if and .Suggest}}, {{end}}{{end -}}
     {{- if and .Suggest }}{{color "cyan"}}{{ print .Config.SuggestInput }} for suggestions{{end -}}
   ]{{color "reset"}} {{end}}
-  {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
 {{- end}}`
 
 func (i *Input) onRune(config *PromptConfig) terminal.OnRuneFn {
@@ -162,7 +161,7 @@ func (i *Input) Prompt(config *PromptConfig) (interface{}, error) {
 		defer cursor.Show() // show the cursor when we're done
 	}
 
-	var line []rune
+	line := []rune(i.Default)
 
 	for {
 		if i.options != nil {
@@ -192,12 +191,6 @@ func (i *Input) Prompt(config *PromptConfig) (interface{}, error) {
 		return i.Prompt(config)
 	}
 
-	// if the line is empty
-	if len(i.answer) == 0 {
-		// use the default value
-		return i.Default, err
-	}
-
 	lineStr := i.answer
 
 	i.AppendRenderedText(lineStr)
@@ -207,12 +200,6 @@ func (i *Input) Prompt(config *PromptConfig) (interface{}, error) {
 }
 
 func (i *Input) Cleanup(config *PromptConfig, val interface{}) error {
-	// use the default answer when cleaning up the prompt if necessary
-	ans := i.answer
-	if ans == "" && i.Default != "" {
-		ans = i.Default
-	}
-
 	// render the cleanup
 	return i.Render(
 		InputQuestionTemplate,
@@ -220,7 +207,7 @@ func (i *Input) Cleanup(config *PromptConfig, val interface{}) error {
 			Input:      *i,
 			ShowAnswer: true,
 			Config:     config,
-			Answer:     ans,
+			Answer:     i.answer,
 		},
 	)
 }


### PR DESCRIPTION
When doing
```golang
survey.Input{
	Message: "What is your name?",
	Default: "Jordan",
}
```
the default value "Jordan" is now editable and can be navigated around with the cursor if `survey.WithShowCursor(true)` was used.

Promoting visibility for this idea: https://github.com/AlecAivazis/survey/issues/196#issuecomment-1067042464

@AlecAivazis Since this is backwards incompatible, what do you think about adding a separate field for editable default value? E.g. `DefaultEditable: "Jordan"`