### PR TITLE
Added customisable hide character for password inputs.

### DIFF
--- a/examples/password.go
+++ b/examples/password.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+// the questions to ask
+var defaultPasswordCharacterPrompt = &survey.Password{
+	Message: "What is your password? (Default hide character)",
+}
+var customPasswordCharacterPrompt = &survey.Password{
+	Message: "What is your password? (Custom hide character)",
+}
+
+func main() {
+
+	var defaultPass string
+	var customPass string
+
+	// ask the question
+	err := survey.AskOne(defaultPasswordCharacterPrompt, &defaultPass)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	fmt.Println()
+	err = survey.AskOne(customPasswordCharacterPrompt, &customPass, survey.WithHideCharacter('-'))
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	// print the answers
+	fmt.Printf("Password 1: %s.\n Password 2: %s\n", defaultPass, customPass)
+}

--- a/password.go
+++ b/password.go
@@ -60,7 +60,7 @@ func (p *Password) Prompt(config *PromptConfig) (interface{}, error) {
 
 	// no help msg?  Just return any response
 	if p.Help == "" {
-		line, err := rr.ReadLine('*')
+		line, err := rr.ReadLine(config.HideCharacter)
 		return string(line), err
 	}
 
@@ -69,7 +69,7 @@ func (p *Password) Prompt(config *PromptConfig) (interface{}, error) {
 	var line []rune
 	// process answers looking for help prompt answer
 	for {
-		line, err = rr.ReadLine('*')
+		line, err = rr.ReadLine(config.HideCharacter)
 		if err != nil {
 			return string(line), err
 		}
@@ -96,7 +96,7 @@ func (p *Password) Prompt(config *PromptConfig) (interface{}, error) {
 	}
 
 	lineStr := string(line)
-	p.AppendRenderedText(strings.Repeat("*", len(lineStr)))
+	p.AppendRenderedText(strings.Repeat(string(config.HideCharacter), len(lineStr)))
 	return lineStr, err
 }
 

--- a/survey.go
+++ b/survey.go
@@ -56,8 +56,9 @@ func defaultAskOptions() *AskOptions {
 				// include this option if it matches
 				return strings.Contains(strings.ToLower(value), filter)
 			},
-			KeepFilter: false,
-			ShowCursor: false,
+			KeepFilter:    false,
+			ShowCursor:    false,
+			HideCharacter: '*',
 		},
 	}
 }
@@ -111,13 +112,14 @@ type Question struct {
 
 // PromptConfig holds the global configuration for a prompt
 type PromptConfig struct {
-	PageSize     int
-	Icons        IconSet
-	HelpInput    string
-	SuggestInput string
-	Filter       func(filter string, option string, index int) bool
-	KeepFilter   bool
-	ShowCursor   bool
+	PageSize      int
+	Icons         IconSet
+	HelpInput     string
+	SuggestInput  string
+	Filter        func(filter string, option string, index int) bool
+	KeepFilter    bool
+	ShowCursor    bool
+	HideCharacter rune
 }
 
 // Prompt is the primary interface for the objects that can take user input
@@ -228,6 +230,17 @@ func WithShowCursor(ShowCursor bool) AskOpt {
 	return func(options *AskOptions) error {
 		// set the page size
 		options.PromptConfig.ShowCursor = ShowCursor
+
+		// nothing went wrong
+		return nil
+	}
+}
+
+// WithHideCharacter sets the default character shown instead of the password for password inputs
+func WithHideCharacter(char rune) AskOpt {
+	return func(options *AskOptions) error {
+		// set the hide character
+		options.PromptConfig.HideCharacter = char
 
 		// nothing went wrong
 		return nil


### PR DESCRIPTION
Hi @AlecAivazis and @mislav!

I had some free time so I tried my hand on implementing #386. 

Changing the hide character of the password field works as expected. However, using an empty rune just results in the characters not getting hidden at all.

The best workaround for this is setting the custom hide character to an [zero width space](https://zerowidthspace.me/). This results in the behaviour required by the original poster.

I included an example for the password input, but I did not write a test for the behaviour. I also noticed that the existing password tests don't actually validate that the input is hidden, just that is is stored correctly. I'm sadly incapable of fixing those two issues.

