### PR TITLE
Fix bugs when deleting characters when prompt is at the bottom of the terminal

### DIFF
--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -179,18 +179,17 @@ func (rr *RuneReader) ReadLineWithDefault(mask rune, d []rune, onRunes ...OnRune
 					EraseLine(rr.stdio.Out, ERASE_LINE_END)
 
 					// Erase symbols which are left over from older print on the next line
-					if cursorCurrent.Y < terminalSize.Y {
-						// store the cursor position to compare it later
-						lastCursorLocation, _ := cursor.Location(rr.Buffer())
 
-						// this moves the cursor down or stays on the same line if no next line exists
-						cursor.NextLine(1)
+					// store the cursor position to compare it later
+					lastCursorLocation, _ := cursor.Location(rr.Buffer())
 
-						// only erase the line if the cursor actually moved down a line
-						newCursorLocation, _ := cursor.Location(rr.Buffer())
-						if lastCursorLocation.Y < newCursorLocation.Y {
-							EraseLine(rr.stdio.Out, ERASE_LINE_END)
-						}
+					// move the cursor down or stay on the same line if no next line exists
+					cursor.NextLine(1)
+
+					// only erase the line if the cursor actually moved down a line
+					newCursorLocation, _ := cursor.Location(rr.Buffer())
+					if lastCursorLocation.Y < newCursorLocation.Y {
+						EraseLine(rr.stdio.Out, ERASE_LINE_END)
 					}
 
 					// restore cursor

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -169,14 +169,16 @@ func (rr *RuneReader) ReadLineWithDefault(mask rune, d []rune, onRunes ...OnRune
 
 					// print what comes after
 					for _, char := range line[index-1:] {
-						//Erase symbols which are left over from older print
-						EraseLine(rr.stdio.Out, ERASE_LINE_END)
 						// print characters to the new line appropriately
 						if err := rr.printChar(char, mask); err != nil {
 							return line, err
 						}
 					}
-					// erase what's left over from last print
+
+					// Erase symbols which are left over from older print on the line after ending printing
+					EraseLine(rr.stdio.Out, ERASE_LINE_END)
+
+					// Erase symbols which are left over from older print on the next line
 					if cursorCurrent.Y < terminalSize.Y {
 						// store the cursor position to compare it later
 						lastCursorLocation, _ := cursor.Location(rr.Buffer())
@@ -186,11 +188,11 @@ func (rr *RuneReader) ReadLineWithDefault(mask rune, d []rune, onRunes ...OnRune
 
 						// only erase the line if the cursor actually moved down a line
 						newCursorLocation, _ := cursor.Location(rr.Buffer())
-
 						if lastCursorLocation.Y < newCursorLocation.Y {
 							EraseLine(rr.stdio.Out, ERASE_LINE_END)
 						}
 					}
+
 					// restore cursor
 					cursor.Restore()
 					if cursorCurrent.CursorIsAtLineBegin() {

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -178,8 +178,18 @@ func (rr *RuneReader) ReadLineWithDefault(mask rune, d []rune, onRunes ...OnRune
 					}
 					// erase what's left over from last print
 					if cursorCurrent.Y < terminalSize.Y {
+						// store the cursor position to compare it later
+						lastCursorLocation, _ := cursor.Location(rr.Buffer())
+
+						// this moves the cursor down or stays on the same line if no next line exists
 						cursor.NextLine(1)
-						EraseLine(rr.stdio.Out, ERASE_LINE_END)
+
+						// only erase the line if the cursor actually moved down a line
+						newCursorLocation, _ := cursor.Location(rr.Buffer())
+
+						if lastCursorLocation.Y < newCursorLocation.Y {
+							EraseLine(rr.stdio.Out, ERASE_LINE_END)
+						}
 					}
 					// restore cursor
 					cursor.Restore()


### PR DESCRIPTION
This fixes #437 by checking if the cursor moved down a line before erasing the line.

When the terminal scrolls down after the text reaches the bottom of the terminal, no next line exists.
So trying to move the cursor down one line just makes it go to the beginning of the same line.
Erasing the line then erases the last line of text, making it invisible.