### PR TITLE
Show transformed answer after submitting input

### DIFF
--- a/input.go
+++ b/input.go
@@ -207,20 +207,13 @@ func (i *Input) Prompt(config *PromptConfig) (interface{}, error) {
 }
 
 func (i *Input) Cleanup(config *PromptConfig, val interface{}) error {
-	// use the default answer when cleaning up the prompt if necessary
-	ans := val.(string)
-	if ans == "" && i.Default != "" {
-		ans = i.Default
-	}
-
-	// render the cleanup
 	return i.Render(
 		InputQuestionTemplate,
 		InputTemplateData{
 			Input:      *i,
 			ShowAnswer: true,
 			Config:     config,
-			Answer:     ans,
+			Answer:     val.(string),
 		},
 	)
 }

--- a/input.go
+++ b/input.go
@@ -208,7 +208,7 @@ func (i *Input) Prompt(config *PromptConfig) (interface{}, error) {
 
 func (i *Input) Cleanup(config *PromptConfig, val interface{}) error {
 	// use the default answer when cleaning up the prompt if necessary
-	ans := i.answer
+	ans := val.(string)
 	if ans == "" && i.Default != "" {
 		ans = i.Default
 	}

--- a/survey_posix_test.go
+++ b/survey_posix_test.go
@@ -31,7 +31,7 @@ func RunTest(t *testing.T, procedure func(expectConsole), test func(terminal.Std
 	donec := make(chan struct{})
 	go func() {
 		defer close(donec)
-		procedure(&consoleWithErrorHandling{console: c, t: t, vt: term})
+		procedure(&consoleWithErrorHandling{console: c, t: t})
 	}()
 
 	stdio := terminal.Stdio{In: c.Tty(), Out: c.Tty(), Err: c.Tty()}

--- a/survey_posix_test.go
+++ b/survey_posix_test.go
@@ -31,7 +31,7 @@ func RunTest(t *testing.T, procedure func(expectConsole), test func(terminal.Std
 	donec := make(chan struct{})
 	go func() {
 		defer close(donec)
-		procedure(&consoleWithErrorHandling{console: c, t: t})
+		procedure(&consoleWithErrorHandling{console: c, t: t, vt: term})
 	}()
 
 	stdio := terminal.Stdio{In: c.Tty(), Out: c.Tty(), Err: c.Tty()}

--- a/survey_test.go
+++ b/survey_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	expect "github.com/Netflix/go-expect"
+	"github.com/hinshun/vt10x"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,6 +21,7 @@ func init() {
 }
 
 type expectConsole interface {
+	TerminalContains(string)
 	ExpectString(string)
 	ExpectEOF()
 	SendLine(string)
@@ -29,6 +31,12 @@ type expectConsole interface {
 type consoleWithErrorHandling struct {
 	console *expect.Console
 	t       *testing.T
+	vt      vt10x.Terminal
+}
+
+func (c *consoleWithErrorHandling) TerminalContains(s string) {
+	c.t.Helper()
+	require.Contains(c.t, c.vt.String(), s)
 }
 
 func (c *consoleWithErrorHandling) ExpectString(s string) {
@@ -381,6 +389,7 @@ func TestAsk(t *testing.T) {
 				c.ExpectString("What is your name?")
 				c.SendLine("Johnny Appleseed")
 				c.ExpectEOF()
+				c.TerminalContains("What is your name? johnny appleseed")
 			},
 			map[string]interface{}{
 				"name": "johnny appleseed",

--- a/survey_test.go
+++ b/survey_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	expect "github.com/Netflix/go-expect"
-	"github.com/hinshun/vt10x"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +20,6 @@ func init() {
 }
 
 type expectConsole interface {
-	TerminalContains(string)
 	ExpectString(string)
 	ExpectEOF()
 	SendLine(string)
@@ -31,12 +29,6 @@ type expectConsole interface {
 type consoleWithErrorHandling struct {
 	console *expect.Console
 	t       *testing.T
-	vt      vt10x.Terminal
-}
-
-func (c *consoleWithErrorHandling) TerminalContains(s string) {
-	c.t.Helper()
-	require.Contains(c.t, c.vt.String(), s)
 }
 
 func (c *consoleWithErrorHandling) ExpectString(s string) {
@@ -388,8 +380,8 @@ func TestAsk(t *testing.T) {
 			func(c expectConsole) {
 				c.ExpectString("What is your name?")
 				c.SendLine("Johnny Appleseed")
+				c.ExpectString("What is your name? johnny appleseed")
 				c.ExpectEOF()
-				c.TerminalContains("What is your name? johnny appleseed")
 			},
 			map[string]interface{}{
 				"name": "johnny appleseed",


### PR DESCRIPTION
Fixes #449.

I tried to use the existing `go-expect` tooling to test this, but had a hard time figuring out how to do so :grimacing:. No amount of fiddling w/ `Console` (or the `Expect*` methods) seemed to be able to get at the output written by `Prompt.Confirm()`. If there's a better way to do this, please let me know and I'll update.
