### PR TITLE
fix issue with double output on windows

### DIFF
--- a/input.go
+++ b/input.go
@@ -200,8 +200,6 @@ func (i *Input) Prompt(config *PromptConfig) (interface{}, error) {
 
 	lineStr := i.answer
 
-	i.AppendRenderedText(lineStr)
-
 	// we're done
 	return lineStr, err
 }


### PR DESCRIPTION
I was able to fix the double output issues on windows by removing this line, did a manual test on Ubuntu as well. My guess is this is not the best solution so let me know.

Fixes #406 and #368 