### PR TITLE
Add TransformInteger feature

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -2,6 +2,7 @@ package survey
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -36,6 +37,22 @@ func TransformString(f func(s string) string) Transformer {
 		}
 
 		return f(s)
+	}
+}
+
+func TransformInteger() Transformer {
+	return func(ans interface{}) interface{} {
+		strValue, ok := ans.(string)
+		if !ok {
+			return 0
+		}
+
+		intValue, err := strconv.Atoi(strValue)
+		if err != nil {
+			return 0
+		}
+
+		return intValue
 	}
 }
 

--- a/transform_test.go
+++ b/transform_test.go
@@ -26,6 +26,34 @@ func TestTransformString(t *testing.T) {
 	testStringTransformer(t, strings.ToLower) // all letters lowercase
 }
 
+func TestTransformInteger(t *testing.T) {
+	type test struct {
+		input    interface{}
+		expected int
+	}
+
+	tests := []test{
+		{input: "150", expected: 150},
+		{input: "dummy string", expected: 0},
+		{input: "a", expected: 0},
+		{input: "150a", expected: 0},
+		{input: "2.7", expected: 0},
+		{input: "2,7", expected: 0},
+		{input: false, expected: 0},
+		{input: []string{"dummy"}, expected: 0},
+		{input: []int{1}, expected: 0},
+		{input: []byte{20}, expected: 0},
+	}
+
+	transformer := TransformInteger()
+
+	for _, tt := range tests {
+		if actual := transformer(tt.input); actual != tt.expected {
+			t.Errorf("TransformInteger transformer failed to transform the input, expected '%d' but got '%v'.", tt.expected, actual)
+		}
+	}
+}
+
 func TestComposeTransformers(t *testing.T) {
 	// create a transformer which makes no sense,
 	// remember: transformer can be used for any type


### PR DESCRIPTION
When users want to use `survey.Ask` method which can return as `map[string]interface{}`, they may need an integer transformer that converts string results to an integer.

For example, if the `survey.Question` is defined as shown below

```go
{
	Name:      "Age",
	Prompt:    &survey.Input{Message: "Age:"},
	Validate:  survey.Required,
},
```

and ask it like

```go
answers := make(map[string]interface{})
if err := survey.Ask(qs, &answers); err != nil {
	panic(err)
}
```

Age field comes as `interface{} | string` type

<img width="283" alt="Screen Shot 2022-10-16 at 14 00 55" src="https://user-images.githubusercontent.com/73517346/196031638-92502ed2-c9d4-489f-88a3-68b6cddf1bb6.png">

In order to use this field as Integer, it is needed to use `strconv.Atoi` method so I wrote down a ready-to-use Transformer.

They use this transformer as 

```go
{
	Name:      "Age",
	Prompt:    &survey.Input{Message: "Age:"},
	Validate:  survey.Required,
        Transform: survey.TransformInteger,
},
```

Age field comes as `interface {} | int` type

<img width="277" alt="Screen Shot 2022-10-16 at 14 05 27" src="https://user-images.githubusercontent.com/73517346/196031831-ede2b7ae-153b-4497-8365-80041ae122c7.png">








