### PR TITLE
OpenBSD removed syscall() calls, use proper ioctl()s instead

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mattn/go-isatty v0.0.8
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.4.0
 )


### PR DESCRIPTION
survey library is broken on OpenBSD because it had removed syscall() interface, can the library switch to ioctls instead?